### PR TITLE
Fix compared items when trying decompressors

### DIFF
--- a/compressor.c
+++ b/compressor.c
@@ -199,7 +199,7 @@ int compressor_uncompress(struct compressor *comp, void *dest, void *src, int si
             comp = compressor[i];
             
             if(comp->id != default_compressor_id && 
-               comp->id != detected_compressor_index && 
+               comp->id != compressor[detected_compressor_index]->id && 
                comp->uncompress)
             {
                 ERROR("Trying to decompress with %s...\n", comp->name);


### PR DESCRIPTION
The position and the ID were compared and valid non-default compressors were skipped. Now we compare only the IDs.

This helped in my particular problem and maybe it should be the default behaviour since you could miss one decompressor.