### PR TITLE
Update patch to squashfs-tools 4.4

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script to download squashfs-tools v4.3, apply the patches, perform a clean build, and install.
+# Script to download squashfs-tools v4.4, apply the patches, perform a clean build, and install.
 
 # If not root, perform 'make install' with sudo
 if [ $UID -eq 0 ]
@@ -19,19 +19,19 @@ fi
 cd $(dirname `readlink  -f $0`)
 
 # Download squashfs4.3.tar.gz if it does not already exist
-if [ ! -e squashfs4.3.tar.gz ]
+if [ ! -e squashfs4.4.tar.gz ]
 then
-    wget https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz
+    wget https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.4/squashfs4.4.tar.gz
 fi
 
 # Remove any previous squashfs4.3 directory to ensure a clean patch/build
-rm -rf squashfs4.3
+rm -rf squashfs4.4
 
 # Extract squashfs4.3.tar.gz
-tar -zxvf squashfs4.3.tar.gz
+tar -zxvf squashfs4.4.tar.gz
 
 # Patch, build, and install the source
-cd squashfs4.3
+cd squashfs4.4
 patch -p0 < ../patches/patch0.txt
 cd squashfs-tools
 make && $SUDO make install

--- a/patches/patch0.txt
+++ b/patches/patch0.txt
@@ -1,6 +1,6 @@
-diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patched/compressor.c
---- squashfs-tools/compressor.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.c	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patched/compressor.c
+--- squashfs-tools/compressor.c	2021-04-15 22:58:59.993587676 -0700
++++ squashfs-tools-patched/compressor.c	2021-04-15 21:24:17.065867146 -0700
 @@ -25,6 +25,9 @@
  #include "compressor.h"
  #include "squashfs_fs.h"
@@ -11,17 +11,14 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patc
  #ifndef GZIP_SUPPORT
  static struct compressor gzip_comp_ops =  {
  	ZLIB_COMPRESSION, "gzip"
-@@ -65,6 +68,9 @@
- extern struct compressor xz_comp_ops;
- #endif
+@@ -77,10 +80,17 @@
+ 	0, "unknown"
+ };
  
 +extern struct compressor lzma_alt_comp_ops;
 +extern struct compressor lzma_wrt_comp_ops;
 +extern struct compressor lzma_adaptive_comp_ops;
  
- static struct compressor unknown_comp_ops = {
- 	0, "unknown"
-@@ -74,6 +80,10 @@
  struct compressor *compressor[] = {
  	&gzip_comp_ops,
  	&lzma_comp_ops,
@@ -32,7 +29,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patc
  	&lzo_comp_ops,
  	&lz4_comp_ops,
  	&xz_comp_ops,
-@@ -81,6 +91,19 @@
+@@ -89,6 +99,19 @@
  };
  
  
@@ -52,7 +49,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patc
  struct compressor *lookup_compressor(char *name)
  {
  	int i;
-@@ -135,3 +158,67 @@
+@@ -143,3 +166,67 @@
  					compressor[i]->name, str);
  		}
  }
@@ -120,9 +117,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patc
 +    return retval;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patched/compressor.h
---- squashfs-tools/compressor.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.h	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patched/compressor.h
+--- squashfs-tools/compressor.h	2021-04-15 22:58:59.993587676 -0700
++++ squashfs-tools-patched/compressor.h	2021-04-15 21:24:17.065867146 -0700
 @@ -59,11 +59,14 @@
  }
  
@@ -138,9 +135,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patc
  
  
  /*
-diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
---- squashfs-tools/error.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/error.h	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
+--- squashfs-tools/error.h	2021-04-15 22:58:59.993587676 -0700
++++ squashfs-tools-patched/error.h	2021-04-15 21:24:17.066867162 -0700
 @@ -30,14 +30,18 @@
  extern void progressbar_error(char *fmt, ...);
  extern void progressbar_info(char *fmt, ...);
@@ -162,9 +159,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/e
  
  #define INFO(s, args...) \
  		do {\
-diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/LICENSE
---- squashfs-tools/LICENSE	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LICENSE	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/LICENSE
+--- squashfs-tools/LICENSE	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LICENSE	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,339 @@
 +                    GNU GENERAL PUBLIC LICENSE
 +                       Version 2, June 1991
@@ -505,9 +502,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/L
 +consider it more useful to permit linking proprietary applications with the
 +library.  If this is what you want to do, use the GNU Lesser General
 +Public License instead of this License.
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-tools-patched/LZMA/lzma465/7zC.txt
---- squashfs-tools/LZMA/lzma465/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-tools-patched/LZMA/lzma465/7zC.txt
+--- squashfs-tools/LZMA/lzma465/7zC.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,194 @@
 +7z ANSI-C Decoder 4.62
 +----------------------
@@ -703,9 +700,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-to
 +http://www.7-zip.org
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squashfs-tools-patched/LZMA/lzma465/7zFormat.txt
---- squashfs-tools/LZMA/lzma465/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squashfs-tools-patched/LZMA/lzma465/7zFormat.txt
+--- squashfs-tools/LZMA/lzma465/7zFormat.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -1178,9 +1175,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squash
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c
+--- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,45 @@
 +/* 7zBuf2.c -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1227,9 +1224,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs
 +  p->size = 0;
 +  p->pos = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c
+--- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,36 @@
 +/* 7zBuf.c -- Byte Buffer
 +2008-03-28
@@ -1267,9 +1264,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-
 +  p->data = 0;
 +  p->size = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h
---- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h
+--- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,31 @@
 +/* 7zBuf.h -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1302,9 +1299,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-
 +void DynBuf_Free(CDynBuf *p, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c
---- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c
+--- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,35 @@
 +/* 7zCrc.c -- CRC32 calculation
 +2008-08-05
@@ -1341,9 +1338,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-
 +{
 +  return CrcUpdate(CRC_INIT_VAL, data, size) ^ 0xFFFFFFFF;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h
---- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h
+--- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2021-04-15 21:24:17.066867162 -0700
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h -- CRC32 calculation
 +2008-03-13
@@ -1369,9 +1366,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-
 +UInt32 MY_FAST_CALL CrcCalc(const void *data, size_t size);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs-tools-patched/LZMA/lzma465/C/7zFile.c
---- squashfs-tools/LZMA/lzma465/C/7zFile.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs-tools-patched/LZMA/lzma465/C/7zFile.c
+--- squashfs-tools/LZMA/lzma465/C/7zFile.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,263 @@
 +/* 7zFile.c -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1636,9 +1633,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs
 +{
 +  p->s.Write = FileOutStream_Write;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs-tools-patched/LZMA/lzma465/C/7zFile.h
---- squashfs-tools/LZMA/lzma465/C/7zFile.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs-tools-patched/LZMA/lzma465/C/7zFile.h
+--- squashfs-tools/LZMA/lzma465/C/7zFile.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,74 @@
 +/* 7zFile.h -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1714,9 +1711,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs
 +void FileOutStream_CreateVTable(CFileOutStream *p);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squashfs-tools-patched/LZMA/lzma465/C/7zStream.c
---- squashfs-tools/LZMA/lzma465/C/7zStream.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squashfs-tools-patched/LZMA/lzma465/C/7zStream.c
+--- squashfs-tools/LZMA/lzma465/C/7zStream.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,169 @@
 +/* 7zStream.c -- 7z Stream functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -1887,9 +1884,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squash
 +{
 +  p->s.Read = SecToRead_Read;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h
---- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h
+--- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,7 @@
 +#define MY_VER_MAJOR 4
 +#define MY_VER_MINOR 65
@@ -1898,9 +1895,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squas
 +#define MY_DATE "2009-02-03"
 +#define MY_COPYRIGHT ": Igor Pavlov : Public domain"
 +#define MY_VERSION_COPYRIGHT_DATE MY_VERSION " " MY_COPYRIGHT " : " MY_DATE
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-tools-patched/LZMA/lzma465/C/Alloc.c
---- squashfs-tools/LZMA/lzma465/C/Alloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-tools-patched/LZMA/lzma465/C/Alloc.c
+--- squashfs-tools/LZMA/lzma465/C/Alloc.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,127 @@
 +/* Alloc.c -- Memory allocation functions
 +2008-09-24
@@ -2029,9 +2026,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-tools-patched/LZMA/lzma465/C/Alloc.h
---- squashfs-tools/LZMA/lzma465/C/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-tools-patched/LZMA/lzma465/C/Alloc.h
+--- squashfs-tools/LZMA/lzma465/C/Alloc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,32 @@
 +/* Alloc.h -- Memory allocation functions
 +2008-03-13
@@ -2065,9 +2062,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,77 @@
 +/* 7zAlloc.c -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2146,9 +2143,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +  #endif
 +  free(address);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,15 @@
 +/* 7zAlloc.h -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2165,9 +2162,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +void SzFreeTemp(void *p, void *address);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2021-04-15 21:24:17.067867177 -0700
 @@ -0,0 +1,254 @@
 +/* 7zDecode.c -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2423,9 +2420,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +    IAlloc_Free(allocMain, tempBuf[i]);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,13 @@
 +/* 7zDecode.h -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2440,9 +2437,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +    Byte *outBuffer, size_t outSize, ISzAlloc *allocMain);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,199 @@
 +# Microsoft Developer Studio Project File - Name="7z" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -2643,9 +2640,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -2676,9 +2673,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,93 @@
 +/* 7zExtract.c -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2773,9 +2770,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +  }
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,41 @@
 +/* 7zExtract.h -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2818,9 +2815,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +    ISzAlloc *allocTemp);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,6 @@
 +/*  7zHeader.c -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2828,9 +2825,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +#include "7zHeader.h"
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,57 @@
 +/* 7zHeader.h -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2889,9 +2886,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2021-04-15 21:24:17.068867192 -0700
 @@ -0,0 +1,1204 @@
 +/* 7zIn.c -- 7z Input functions
 +2008-12-31 : Igor Pavlov : Public domain */
@@ -4097,9 +4094,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c
 +    SzArEx_Free(p, allocMain);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,41 @@
 +/* 7zIn.h -- 7z Input functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4142,9 +4139,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h
 +SRes SzArEx_Open(CSzArEx *p, ILookInStream *inStream, ISzAlloc *allocMain, ISzAlloc *allocTemp);
 + 
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,127 @@
 +/* 7zItem.c -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4273,9 +4270,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +  IAlloc_Free(alloc, p->Files);
 +  SzAr_Init(p);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,84 @@
 +/* 7zItem.h -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4361,9 +4358,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +void SzAr_Free(CSzAr *p, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,262 @@
 +/* 7zMain.c - Test application for 7z Decoder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4627,9 +4624,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain
 +    printf("\nERROR #%d\n", res);
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,33 @@
 +MY_STATIC_LINK=1
 +
@@ -4664,9 +4661,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +	$(COMPL_O1)
 +$(C_OBJS): ../../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,61 @@
 +PROG = 7zDec
 +CXX = g++
@@ -4729,9 +4726,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c
---- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c
+--- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,132 @@
 +/* Bcj2.c -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4865,9 +4862,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-t
 +  }
 +  return (outPos == outSize) ? SZ_OK : SZ_ERROR_DATA;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h
---- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h
+--- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2021-04-15 21:24:17.069867208 -0700
 @@ -0,0 +1,30 @@
 +/* Bcj2.h -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4899,9 +4896,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-t
 +    Byte *outBuf, SizeT outSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-tools-patched/LZMA/lzma465/C/Bra86.c
---- squashfs-tools/LZMA/lzma465/C/Bra86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-tools-patched/LZMA/lzma465/C/Bra86.c
+--- squashfs-tools/LZMA/lzma465/C/Bra86.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2021-04-15 21:24:17.070867223 -0700
 @@ -0,0 +1,85 @@
 +/* Bra86.c -- Converter for x86 code (BCJ)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4988,9 +4985,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-
 +  *state = ((prevPosT > 3) ? 0 : ((prevMask << ((int)prevPosT - 1)) & 0x7));
 +  return bufferPos;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-tools-patched/LZMA/lzma465/C/Bra.c
---- squashfs-tools/LZMA/lzma465/C/Bra.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-tools-patched/LZMA/lzma465/C/Bra.c
+--- squashfs-tools/LZMA/lzma465/C/Bra.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2021-04-15 21:24:17.070867223 -0700
 @@ -0,0 +1,133 @@
 +/* Bra.c -- Converters for RISC code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5125,9 +5122,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-to
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-tools-patched/LZMA/lzma465/C/Bra.h
---- squashfs-tools/LZMA/lzma465/C/Bra.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-tools-patched/LZMA/lzma465/C/Bra.h
+--- squashfs-tools/LZMA/lzma465/C/Bra.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2021-04-15 21:24:17.070867223 -0700
 @@ -0,0 +1,60 @@
 +/* Bra.h -- Branch converters for executables
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5189,9 +5186,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-to
 +SizeT IA64_Convert(Byte *data, SizeT size, UInt32 ip, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c
---- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c
+--- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2021-04-15 21:24:17.070867223 -0700
 @@ -0,0 +1,67 @@
 +/* BraIA64.c -- Converter for IA-64 code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5260,9 +5257,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashf
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h
---- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h
+--- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2021-04-15 21:24:17.070867223 -0700
 @@ -0,0 +1,69 @@
 +/* CpuArch.h
 +2008-08-05
@@ -5333,9 +5330,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashf
 +#define GetBe16(p) (((UInt16)((const Byte *)(p))[0] << 8) | ((const Byte *)(p))[1])
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs-tools-patched/LZMA/lzma465/C/LzFind.c
---- squashfs-tools/LZMA/lzma465/C/LzFind.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs-tools-patched/LZMA/lzma465/C/LzFind.c
+--- squashfs-tools/LZMA/lzma465/C/LzFind.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2021-04-15 21:24:17.070867223 -0700
 @@ -0,0 +1,751 @@
 +/* LzFind.c -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6088,9 +6085,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs
 +    vTable->Skip = (Mf_Skip_Func)Bt4_MatchFinder_Skip;
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs-tools-patched/LZMA/lzma465/C/LzFind.h
---- squashfs-tools/LZMA/lzma465/C/LzFind.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs-tools-patched/LZMA/lzma465/C/LzFind.h
+--- squashfs-tools/LZMA/lzma465/C/LzFind.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2021-04-15 21:24:17.070867223 -0700
 @@ -0,0 +1,107 @@
 +/* LzFind.h -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6199,9 +6196,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs
 +void Hc3Zip_MatchFinder_Skip(CMatchFinder *p, UInt32 num);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c
+--- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2021-04-15 21:24:17.071867239 -0700
 @@ -0,0 +1,793 @@
 +/* LzFindMt.c -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6996,9 +6993,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squash
 +    */
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h
+--- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2021-04-15 21:24:17.071867239 -0700
 @@ -0,0 +1,97 @@
 +/* LzFindMt.h -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7097,9 +7094,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squash
 +void MatchFinderMt_ReleaseStream(CMatchFinderMt *p);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs-tools-patched/LZMA/lzma465/C/LzHash.h
---- squashfs-tools/LZMA/lzma465/C/LzHash.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs-tools-patched/LZMA/lzma465/C/LzHash.h
+--- squashfs-tools/LZMA/lzma465/C/LzHash.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2021-04-15 21:24:17.071867239 -0700
 @@ -0,0 +1,54 @@
 +/* LzHash.h -- HASH functions for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7155,9 +7152,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs
 +  hash4Value = (temp ^ ((UInt32)cur[2] << 8) ^ (p->crc[cur[3]] << 5)) & (kHash4Size - 1); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2021-04-15 21:24:17.071867239 -0700
 @@ -0,0 +1,1007 @@
 +/* LzmaDec.c -- LZMA Decoder
 +2008-11-06 : Igor Pavlov : Public domain */
@@ -8166,9 +8163,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashf
 +  LzmaDec_FreeProbs(&p, alloc);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2021-04-15 21:24:17.071867239 -0700
 @@ -0,0 +1,223 @@
 +/* LzmaDec.h -- LZMA Decoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -8393,9 +8390,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashf
 +    ELzmaStatus *status, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,2281 @@
 +/* LzmaEnc.c -- LZMA Encoder
 +2009-02-02 : Igor Pavlov : Public domain */
@@ -10678,9 +10675,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashf
 +  LzmaEnc_Destroy(p, alloc, allocBig);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,72 @@
 +/*  LzmaEnc.h -- LZMA Encoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10754,17 +10751,17 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashf
 +    ICompressProgress *progress, ISzAlloc *alloc, ISzAlloc *allocBig);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,4 @@
 +EXPORTS
 +  LzmaCompress
 +  LzmaUncompress
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="LzmaLib" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -10944,9 +10941,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -10977,9 +10974,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,12 @@
 +/* LzmaLibExports.c -- LZMA library DLL Entry point
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10993,9 +10990,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibEx
 +  lpReserved = lpReserved;
 +  return TRUE;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,37 @@
 +MY_STATIC_LINK=1
 +SLIB = sLZMA.lib
@@ -11034,17 +11031,17 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile 
 +	$(COMPL_O2)
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,4 @@
 +#include "../../CPP/7zip/MyVersionInfo.rc"
 +
 +MY_VERSION_INFO_DLL("LZMA library", "LZMA")
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2021-04-15 21:24:17.072867254 -0700
 @@ -0,0 +1,46 @@
 +/* LzmaLib.c -- LZMA library wrapper
 +2008-08-05
@@ -11092,9 +11089,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashf
 +  ELzmaStatus status;
 +  return LzmaDecode(dest, destLen, src, srcLen, props, (unsigned)propsSize, LZMA_FINISH_ANY, &status, &g_Alloc);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,135 @@
 +/* LzmaLib.h -- LZMA library interface
 +2008-08-05
@@ -11231,9 +11228,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashf
 +  const unsigned char *props, size_t propsSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,61 @@
 +/* Lzma86Dec.c -- LZMA + x86 (BCJ) Filter Decoder
 +2008-04-07
@@ -11296,9 +11293,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +  }
 +  return SZ_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,45 @@
 +/* Lzma86Dec.h -- LZMA + x86 (BCJ) Filter Decoder
 +2008-08-05
@@ -11345,9 +11342,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +SRes Lzma86_Decode(Byte *dest, SizeT *destLen, const Byte *src, SizeT *srcLen);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,113 @@
 +/* Lzma86Enc.c -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11462,9 +11459,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +    MyFree(filteredStream);
 +  return mainResult;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,72 @@
 +/* Lzma86Enc.h -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11538,9 +11535,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +    int level, UInt32 dictSize, int filterMode);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,254 @@
 +/* LzmaUtil.c -- Test application for LZMA compression
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -11796,9 +11793,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,168 @@
 +# Microsoft Developer Studio Project File - Name="LzmaUtil" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -11968,9 +11965,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -12001,9 +11998,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,29 @@
 +MY_STATIC_LINK=1
 +PROG = LZMAc.exe
@@ -12034,9 +12031,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +	$(COMPL_O2)
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2021-04-15 21:24:17.073867269 -0700
 @@ -0,0 +1,44 @@
 +PROG = lzma
 +CXX = g++
@@ -12082,9 +12079,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashfs-tools-patched/LZMA/lzma465/C/Threads.c
---- squashfs-tools/LZMA/lzma465/C/Threads.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashfs-tools-patched/LZMA/lzma465/C/Threads.c
+--- squashfs-tools/LZMA/lzma465/C/Threads.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,109 @@
 +/* Threads.c -- multithreading library
 +2008-08-05
@@ -12195,9 +12192,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashf
 +  return 0;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashfs-tools-patched/LZMA/lzma465/C/Threads.h
---- squashfs-tools/LZMA/lzma465/C/Threads.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashfs-tools-patched/LZMA/lzma465/C/Threads.h
+--- squashfs-tools/LZMA/lzma465/C/Threads.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,68 @@
 +/* Threads.h -- multithreading library
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -12267,9 +12264,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashf
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-tools-patched/LZMA/lzma465/C/Types.h
---- squashfs-tools/LZMA/lzma465/C/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-tools-patched/LZMA/lzma465/C/Types.h
+--- squashfs-tools/LZMA/lzma465/C/Types.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,208 @@
 +/* Types.h -- Basic types
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -12479,9 +12476,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-
 +#define IAlloc_Free(p, a) (p)->Free((p), a)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashfs-tools-patched/LZMA/lzma465/history.txt
---- squashfs-tools/LZMA/lzma465/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/history.txt	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashfs-tools-patched/LZMA/lzma465/history.txt
+--- squashfs-tools/LZMA/lzma465/history.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/history.txt	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,236 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -12719,9 +12716,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashf
 +  
 +
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-tools-patched/LZMA/lzma465/lzma.txt
---- squashfs-tools/LZMA/lzma465/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-tools-patched/LZMA/lzma465/lzma.txt
+--- squashfs-tools/LZMA/lzma465/lzma.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,594 @@
 +LZMA SDK 4.65
 +-------------
@@ -13317,9 +13314,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-t
 +http://www.7-zip.org
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashfs-tools-patched/LZMA/lzma465/Methods.txt
---- squashfs-tools/LZMA/lzma465/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashfs-tools-patched/LZMA/lzma465/Methods.txt
+--- squashfs-tools/LZMA/lzma465/Methods.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,137 @@
 +7-Zip method IDs (4.65)
 +-----------------------
@@ -13458,9 +13455,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashf
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt
---- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt
+--- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,235 @@
 +7z ANSI-C Decoder 4.23
 +----------------------
@@ -13697,9 +13694,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashf
 +
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt
---- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt
+--- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2021-04-15 21:24:17.074867285 -0700
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -14172,9 +14169,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt sq
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,70 @@
 +/* 7zAlloc.c */
 +
@@ -14246,9 +14243,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  #endif
 +  free(address);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,20 @@
 +/* 7zAlloc.h */
 +
@@ -14270,9 +14267,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +void SzFreeTemp(void *address);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,29 @@
 +/* 7zBuffer.c */
 +
@@ -14303,9 +14300,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  buffer->Items = 0;
 +  buffer->Capacity = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,19 @@
 +/* 7zBuffer.h */
 +
@@ -14326,9 +14323,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +void SzByteBufferFree(CSzByteBuffer *buffer, void (*freeFunc)(void *));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="7z_C" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -14508,9 +14505,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -14541,9 +14538,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,76 @@
 +/* 7zCrc.c */
 +
@@ -14621,9 +14618,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +{
 +  return (CrcCalculateDigest(data, size) == digest);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h */
 +
@@ -14649,9 +14646,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +int CrcVerifyDigest(UInt32 digest, const void *data, size_t size);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,150 @@
 +/* 7zDecode.c */
 +
@@ -14803,9 +14800,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  }
 +  return SZE_NOTIMPL;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2021-04-15 21:24:17.075867300 -0700
 @@ -0,0 +1,21 @@
 +/* 7zDecode.h */
 +
@@ -14828,9 +14825,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    size_t *outSizeProcessed, ISzAlloc *allocMain);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,116 @@
 +/* 7zExtract.c */
 +
@@ -14948,9 +14945,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  }
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,40 @@
 +/* 7zExtract.h */
 +
@@ -14992,18 +14989,18 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    ISzAlloc *allocTemp);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,5 @@
 +/*  7zHeader.c */
 +
 +#include "7zHeader.h"
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,55 @@
 +/* 7zHeader.h */
 +
@@ -15060,9 +15057,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,1292 @@
 +/* 7zIn.c */
 +
@@ -16356,9 +16353,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    SzArDbExFree(db, allocMain->Free);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,55 @@
 +/* 7zIn.h */
 +
@@ -16415,9 +16412,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    ISzAlloc *allocTemp);
 + 
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,133 @@
 +/* 7zItem.c */
 +
@@ -16552,9 +16549,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  freeFunc(db->Files);
 +  SzArchiveDatabaseInit(db);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2021-04-15 21:24:17.076867316 -0700
 @@ -0,0 +1,90 @@
 +/* 7zItem.h */
 +
@@ -16646,9 +16643,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,223 @@
 +/* 
 +7zMain.c
@@ -16873,9 +16870,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    printf("\nERROR #%d\n", res);
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,14 @@
 +/* 7zMethodID.c */
 +
@@ -16891,9 +16888,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +      return 0;
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,18 @@
 +/* 7zMethodID.h */
 +
@@ -16913,9 +16910,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +int AreMethodsEqual(CMethodID *a1, CMethodID *a2);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,61 @@
 +/* 7zTypes.h */
 +
@@ -16978,9 +16975,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#define RINOK(x) { int __result_ = (x); if(__result_ != 0) return __result_; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,55 @@
 +PROG = 7zDec.exe
 +
@@ -17037,9 +17034,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +	$(COMPL)
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,50 @@
 +PROG = 7zDec
 +CXX = g++
@@ -17091,9 +17088,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,251 @@
 +// FileStreams.cpp
 +
@@ -17346,9 +17343,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +}
 +  
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,98 @@
 +// FileStreams.h
 +
@@ -17448,9 +17445,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,80 @@
 +// InBuffer.cpp
 +
@@ -17532,9 +17529,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +    return 0xFF;
 +  return *_buffer++;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,76 @@
 +// InBuffer.h
 +
@@ -17612,9 +17609,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2021-04-15 21:24:17.077867331 -0700
 @@ -0,0 +1,117 @@
 +// OutByte.cpp
 +
@@ -17733,9 +17730,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +    throw COutBufferException(result);
 +  #endif
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,64 @@
 +// OutBuffer.h
 +
@@ -17801,9 +17798,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -17814,9 +17811,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +#include "../../Common/NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,44 @@
 +// StreamUtils.cpp
 +
@@ -17862,9 +17859,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +  }
 +  return S_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,11 @@
 +// StreamUtils.h
 +
@@ -17877,9 +17874,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +HRESULT WriteStream(ISequentialOutStream *stream, const void *data, UInt32 size, UInt32 *processedSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,16 @@
 +// ARM.cpp
 +
@@ -17897,9 +17894,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::ARM_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,10 @@
 +// ARM.h
 +
@@ -17911,9 +17908,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_ARM, 0x05, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,16 @@
 +// ARMThumb.cpp
 +
@@ -17931,9 +17928,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::ARMThumb_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,10 @@
 +// ARMThumb.h
 +
@@ -17945,9 +17942,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_ARMThumb, 0x07, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,26 @@
 +// BranchARM.c
 +
@@ -17975,9 +17972,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,10 @@
 +// BranchARM.h
 +
@@ -17989,9 +17986,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 ARM_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2021-04-15 21:24:17.078867347 -0700
 @@ -0,0 +1,35 @@
 +// BranchARMThumb.c
 +
@@ -18028,9 +18025,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,10 @@
 +// BranchARMThumb.h
 +
@@ -18042,9 +18039,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 ARMThumb_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,18 @@
 +// BranchCoder.cpp
 +
@@ -18064,9 +18061,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  _bufferPos += processedSize;
 +  return processedSize;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,54 @@
 +// BranchCoder.h
 +
@@ -18122,9 +18119,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassDecoderB(Name ## _Decoder, ADD_ITEMS, ADD_INIT)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,65 @@
 +// BranchIA64.c
 +
@@ -18191,9 +18188,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,10 @@
 +// BranchIA64.h
 +
@@ -18205,9 +18202,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 IA64_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,36 @@
 +// BranchPPC.c
 +
@@ -18245,9 +18242,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,10 @@
 +// BranchPPC.h
 +
@@ -18259,9 +18256,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 PPC_B_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,36 @@
 +// BranchSPARC.c
 +
@@ -18299,9 +18296,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,10 @@
 +// BranchSPARC.h
 +
@@ -18313,9 +18310,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 SPARC_B_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,101 @@
 +/* BranchX86.c */
 +
@@ -18418,9 +18415,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return bufferPos;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,19 @@
 +/* BranchX86.h */
 +
@@ -18441,9 +18438,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    UInt32 *prevMask, UInt32 *prevPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,16 @@
 +// IA64.cpp
 +
@@ -18461,9 +18458,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::IA64_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2021-04-15 21:24:17.079867362 -0700
 @@ -0,0 +1,10 @@
 +// IA64.h
 +
@@ -18475,9 +18472,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_IA64, 0x04, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,17 @@
 +// PPC.cpp
 +
@@ -18496,9 +18493,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::PPC_B_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,10 @@
 +// PPC.h
 +
@@ -18510,9 +18507,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_PPC_B, 0x02, 5)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,17 @@
 +// SPARC.cpp
 +
@@ -18531,9 +18528,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::SPARC_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,10 @@
 +// SPARC.h
 +
@@ -18545,9 +18542,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_SPARC, 0x08, 5)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -18557,9 +18554,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,412 @@
 +// x86_2.cpp
 +
@@ -18973,9 +18970,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  catch(const COutBufferException &e) { return e.ErrorCode; }
 +  catch(...) { return S_FALSE; }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,133 @@
 +// x86_2.h
 +
@@ -19110,9 +19107,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}; 
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,18 @@
 +// x86.cpp
 +
@@ -19132,9 +19129,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::x86_Convert(data, size, _bufferPos, &_prevMask, &_prevPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,19 @@
 +// x86.h
 +
@@ -19155,9 +19152,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    virtual void SubInit() { x86Init(); })
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,12 @@
 +// BinTree2.h
 +
@@ -19171,9 +19168,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "BinTreeMain.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2021-04-15 21:24:17.080867378 -0700
 @@ -0,0 +1,16 @@
 +// BinTree3.h
 +
@@ -19191,9 +19188,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_ARRAY_2
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,16 @@
 +// BinTree3Z.h
 +
@@ -19211,9 +19208,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_ZIP
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,20 @@
 +// BinTree4b.h
 +
@@ -19235,9 +19232,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_BIG
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,18 @@
 +// BinTree4.h
 +
@@ -19257,9 +19254,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#undef HASH_ARRAY_3
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,55 @@
 +// BinTree.h
 +
@@ -19316,9 +19313,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,444 @@
 +// BinTreeMain.h
 +
@@ -19764,9 +19761,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 + 
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,13 @@
 +// HC2.h
 +
@@ -19781,9 +19778,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,17 @@
 +// HC3.h
 +
@@ -19802,9 +19799,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,21 @@
 +// HC4b.h
 +
@@ -19827,9 +19824,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,19 @@
 +// HC4.h
 +
@@ -19850,9 +19847,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2021-04-15 21:24:17.081867393 -0700
 @@ -0,0 +1,55 @@
 +// HC.h
 +
@@ -19909,9 +19906,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,350 @@
 +// HC.h
 +
@@ -20263,9 +20260,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 + 
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,63 @@
 +// MatchFinders/IMatchFinder.h
 +
@@ -20330,9 +20327,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +*/
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,102 @@
 +// LZInWindow.cpp
 +
@@ -20436,9 +20433,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  _buffer -= offset;
 +  AfterMoveBlock();
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,84 @@
 +// LZInWindow.h
 +
@@ -20524,9 +20521,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,17 @@
 +// LZOutWindow.cpp
 +
@@ -20545,9 +20542,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,64 @@
 +// LZOutWindow.h
 +
@@ -20613,9 +20610,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,22 @@
 +// Pat2.h
 +
@@ -20639,9 +20636,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,24 @@
 +// Pat2H.h
 +
@@ -20667,9 +20664,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,20 @@
 +// Pat2R.h
 +
@@ -20691,9 +20688,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2021-04-15 21:24:17.082867408 -0700
 @@ -0,0 +1,24 @@
 +// Pat3H.h
 +
@@ -20719,9 +20716,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2021-04-15 21:24:17.083867424 -0700
 @@ -0,0 +1,24 @@
 +// Pat4H.h
 +
@@ -20747,9 +20744,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2021-04-15 21:24:17.083867424 -0700
 @@ -0,0 +1,318 @@
 +// Pat.h
 +
@@ -21069,9 +21066,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +// #endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2021-04-15 21:24:17.083867424 -0700
 @@ -0,0 +1,989 @@
 +// PatMain.h
 +
@@ -22062,9 +22059,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2021-04-15 21:24:17.083867424 -0700
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -22072,9 +22069,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define __STDAFX_H
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2021-04-15 21:24:17.083867424 -0700
 @@ -0,0 +1,342 @@
 +// LZMADecoder.cpp
 +
@@ -22418,9 +22415,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2021-04-15 21:24:17.083867424 -0700
 @@ -0,0 +1,249 @@
 +// LZMA/Decoder.h
 +
@@ -22671,9 +22668,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2021-04-15 21:24:17.084867439 -0700
 @@ -0,0 +1,1504 @@
 +// LZMA/Encoder.cpp
 +
@@ -24179,9 +24176,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2021-04-15 21:24:17.084867439 -0700
 @@ -0,0 +1,416 @@
 +// LZMA/Encoder.h
 +
@@ -24599,9 +24596,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2021-04-15 21:24:17.084867439 -0700
 @@ -0,0 +1,82 @@
 +// LZMA.h
 +
@@ -24685,9 +24682,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2021-04-15 21:24:17.084867439 -0700
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -24697,9 +24694,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2021-04-15 21:24:17.084867439 -0700
 @@ -0,0 +1,523 @@
 +# Microsoft Developer Studio Project File - Name="AloneLZMA" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -25224,9 +25221,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2021-04-15 21:24:17.084867439 -0700
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -25257,9 +25254,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,509 @@
 +// LzmaAlone.cpp
 +
@@ -25770,9 +25767,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    return 1; 
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,508 @@
 +// LzmaBench.cpp
 +
@@ -26282,9 +26279,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  fprintf(f, "    Average\n");
 +  return 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,11 @@
 +// LzmaBench.h
 +
@@ -26297,9 +26294,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +int LzmaBenchmark(FILE *f, UInt32 numIterations, UInt32 dictionarySize, bool isBT4);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,228 @@
 +// LzmaRam.cpp
 +
@@ -26529,9 +26526,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  } catch(...) { return SZE_OUTOFMEMORY; }
 +  #endif
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,79 @@
 +/* LzmaRamDecode.c */
 +
@@ -26612,9 +26609,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,55 @@
 +/* LzmaRamDecode.h */
 +
@@ -26671,9 +26668,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    void (*freeFunc)(void *));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,46 @@
 +// LzmaRam.h
 +
@@ -26721,9 +26718,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    UInt32 dictionarySize, ESzFilterMode filterMode);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2021-04-15 21:24:17.085867455 -0700
 @@ -0,0 +1,100 @@
 +PROG = lzma.exe
 +CFLAGS = $(CFLAGS) -I ../../../
@@ -26825,9 +26822,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL)
 +$O\FileIO.obj: ../../../Windows/FileIO.cpp
 +	$(COMPL)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,113 @@
 +PROG = lzma
 +CXX = g++ -O2 -Wall
@@ -26942,16 +26939,16 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,3 @@
 +// StdAfx.cpp
 +
 +#include "StdAfx.h"
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -26961,9 +26958,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,588 @@
 +/*
 +  LzmaDecode.c
@@ -27553,9 +27550,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  *outSizeProcessed = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,131 @@
 +/* 
 +  LzmaDecode.h
@@ -27688,9 +27685,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    unsigned char *outStream, SizeT outSize, SizeT *outSizeProcessed);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,716 @@
 +/*
 +  LzmaDecodeSize.c
@@ -28408,9 +28405,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  *outSizeProcessed = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,521 @@
 +/*
 +  LzmaStateDecode.c
@@ -28933,9 +28930,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  (*outSizeProcessed) = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2021-04-15 21:24:17.086867470 -0700
 @@ -0,0 +1,115 @@
 +/* 
 +  LzmaStateDecode.h
@@ -29052,9 +29049,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    int finishDecoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2021-04-15 21:24:17.087867485 -0700
 @@ -0,0 +1,195 @@
 +/* 
 +LzmaStateTest.c
@@ -29251,9 +29248,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2021-04-15 21:24:17.087867485 -0700
 @@ -0,0 +1,342 @@
 +/* 
 +LzmaTest.c
@@ -29597,9 +29594,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2021-04-15 21:24:17.087867485 -0700
 @@ -0,0 +1,43 @@
 +PROG = lzmaDec.exe
 +
@@ -29644,9 +29641,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL)
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2021-04-15 21:24:17.087867485 -0700
 @@ -0,0 +1,23 @@
 +PROG = lzmadec
 +CXX = gcc 
@@ -29671,9 +29668,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2021-04-15 21:24:17.087867485 -0700
 @@ -0,0 +1,21 @@
 +#ifndef __LZMA_LIB_H__
 +#define __LZMA_LIB_H__
@@ -29696,9 +29693,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +int lzmaspec_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int lc, int lp, int pb, int dictionary_size, int offset));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2021-04-15 21:24:17.087867485 -0700
 @@ -0,0 +1,92 @@
 +PROG = liblzmalib.a
 +CXX = g++ -O3 -Wall
@@ -29792,9 +29789,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2021-04-15 21:24:17.088867501 -0700
 @@ -0,0 +1,451 @@
 +/*
 + * lzma zlib simplified wrapper
@@ -30247,9 +30244,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	return Z_OK;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2021-04-15 21:24:17.088867501 -0700
 @@ -0,0 +1,80 @@
 +// Compress/RangeCoder/RangeCoderBit.cpp
 +
@@ -30331,9 +30328,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2021-04-15 21:24:17.088867501 -0700
 @@ -0,0 +1,120 @@
 +// Compress/RangeCoder/RangeCoderBit.h
 +
@@ -30455,9 +30452,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2021-04-15 21:24:17.088867501 -0700
 @@ -0,0 +1,161 @@
 +// Compress/RangeCoder/RangeCoderBitTree.h
 +
@@ -30620,9 +30617,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2021-04-15 21:24:17.088867501 -0700
 @@ -0,0 +1,205 @@
 +// Compress/RangeCoder/RangeCoder.h
 +
@@ -30829,9 +30826,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2021-04-15 21:24:17.088867501 -0700
 @@ -0,0 +1,31 @@
 +// Compress/RangeCoder/RangeCoderOpt.h
 +
@@ -30864,9 +30861,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define RC_GETBIT(numMoveBits, prob, mi) RC_GETBIT2(numMoveBits, prob, mi, ; , ;)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2021-04-15 21:24:17.088867501 -0700
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -30874,9 +30871,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define __STDAFX_H
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,156 @@
 +// ICoder.h
 +
@@ -31034,9 +31031,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2016-08-25 09:06:03.227530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,62 @@
 +// IStream.h
 +
@@ -31100,9 +31097,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,118 @@
 +// Common/Alloc.cpp
 +
@@ -31222,9 +31219,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,29 @@
 +// Common/Alloc.h
 +
@@ -31255,9 +31252,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,78 @@
 +// Common/C_FileIO.h
 +
@@ -31337,9 +31334,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +}
 +
 +}}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,45 @@
 +// Common/C_FileIO.h
 +
@@ -31386,9 +31383,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +}}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,263 @@
 +// CommandLineParser.cpp
 +
@@ -31653,9 +31650,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +}
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,82 @@
 +// Common/CommandLineParser.h
 +
@@ -31739,9 +31736,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,17 @@
 +// ComTry.h
 +
@@ -31760,9 +31757,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry
 +  // catch(...) { return E_FAIL; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2021-04-15 21:24:17.089867516 -0700
 @@ -0,0 +1,61 @@
 +// Common/CRC.cpp
 +
@@ -31825,9 +31822,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cp
 +    v = Table[((Byte)(v)) ^ *p] ^ (v >> 8);
 +  _value = v;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,36 @@
 +// Common/CRC.h
 +
@@ -31865,9 +31862,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h 
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,20 @@
 +// Common/Defs.h
 +
@@ -31889,9 +31886,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h
 +  { return (value != 0); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,203 @@
 +// MyCom.h
 +
@@ -32096,9 +32093,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.
 +  )
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,54 @@
 +// Common/MyGuidDef.h
 +
@@ -32154,9 +32151,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuid
 +  #define DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
 +    MY_EXTERN_C const GUID name
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,13 @@
 +// Common/MyInitGuid.h
 +
@@ -32171,9 +32168,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInit
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,24 @@
 +// MyUnknown.h
 +
@@ -32199,9 +32196,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnkn
 +#endif
 +  
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,183 @@
 +// MyWindows.h
 +
@@ -32386,9 +32383,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWind
 +
 +#endif
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,114 @@
 +// NewHandler.cpp
 + 
@@ -32504,9 +32501,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +  // _set_new_handler(MemErrorOldVCFunction);
 +}
 +*/
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,14 @@
 +// Common/NewHandler.h
 +
@@ -32522,9 +32519,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +operator delete(void *p) throw();
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -32535,9 +32532,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx
 +#include "NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2021-04-15 21:24:17.090867532 -0700
 @@ -0,0 +1,93 @@
 +// Common/StringConvert.cpp
 +
@@ -32632,9 +32629,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,71 @@
 +// Common/StringConvert.h
 +
@@ -32707,9 +32704,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,198 @@
 +// Common/String.cpp
 +
@@ -32909,9 +32906,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +  return MyStringCompareNoCase(MultiByteToUnicodeString(s1), MultiByteToUnicodeString(s2));
 +}
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,631 @@
 +// Common/String.h
 +
@@ -33544,9 +33541,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +typedef CObjectVector<CSysString> CSysStringVector;
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,68 @@
 +// Common/StringToInt.cpp
 +
@@ -33616,9 +33613,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +    return -(Int64)ConvertStringToUInt64(s + 1, end);
 +  return ConvertStringToUInt64(s, end);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,17 @@
 +// Common/StringToInt.h
 +
@@ -33637,9 +33634,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,19 @@
 +// Common/Types.h
 +
@@ -33660,9 +33657,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,74 @@
 +// Common/Vector.cpp
 +
@@ -33738,9 +33735,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +    _size -= num;
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,211 @@
 +// Common/Vector.h
 +
@@ -33953,9 +33950,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +};
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2021-04-15 21:24:17.091867547 -0700
 @@ -0,0 +1,18 @@
 +// Windows/Defs.h
 +
@@ -33975,9 +33972,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.
 +  { return (value != VARIANT_FALSE); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,245 @@
 +// Windows/FileIO.cpp
 +
@@ -34224,9 +34221,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +}
 +
 +}}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,98 @@
 +// Windows/FileIO.h
 +
@@ -34326,9 +34323,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +}}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -34339,9 +34336,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAf
 +#include "../Common/NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squashfs-tools-patched/LZMA/lzmadaptive/CPL.html
---- squashfs-tools/LZMA/lzmadaptive/CPL.html	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squashfs-tools-patched/LZMA/lzmadaptive/CPL.html
+--- squashfs-tools/LZMA/lzmadaptive/CPL.html	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,224 @@
 +<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 +<HTML><HEAD><TITLE>Common Public License - v 1.0</TITLE>
@@ -34567,9 +34564,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squash
 +any resulting litigation.</FONT> 
 +<P><FONT size=2></FONT><FONT size=2></FONT>
 +<P><FONT size=2></FONT></P></BODY></HTML>
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squashfs-tools-patched/LZMA/lzmadaptive/history.txt
---- squashfs-tools/LZMA/lzmadaptive/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squashfs-tools-patched/LZMA/lzmadaptive/history.txt
+--- squashfs-tools/LZMA/lzmadaptive/history.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,147 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -34718,9 +34715,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squ
 +  
 +
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt
---- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt
+--- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,504 @@
 +      GNU LESSER GENERAL PUBLIC LICENSE
 +           Version 2.1, February 1999
@@ -35226,9 +35223,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squash
 +That's all there is to it!
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt
---- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt
+--- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,637 @@
 +LZMA SDK 4.32
 +-------------
@@ -35867,9 +35864,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squash
 +
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt
---- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt
+--- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2021-04-15 21:24:17.092867562 -0700
 @@ -0,0 +1,114 @@
 +Compression method IDs (4.27)
 +-----------------------------
@@ -35985,9 +35982,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squ
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-tools-patched/LZMA/lzmalt/7zlzma.c
---- squashfs-tools/LZMA/lzmalt/7zlzma.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-tools-patched/LZMA/lzmalt/7zlzma.c
+--- squashfs-tools/LZMA/lzmalt/7zlzma.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,58 @@
 +#include "lzmalt.h"
 +
@@ -36047,9 +36044,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-to
 +#endif
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h
---- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h
+--- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,51 @@
 +#ifndef __COMPRESSION_BITCODER_H
 +#define __COMPRESSION_BITCODER_H
@@ -36102,9 +36099,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squash
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h
---- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h
+--- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,160 @@
 +#ifndef __BITTREECODER_H
 +#define __BITTREECODER_H
@@ -36266,9 +36263,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squas
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c
+--- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,39 @@
 +#include "stdlib.h"
 +#include "IInOutStreams.h"
@@ -36309,9 +36306,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squa
 +        return (BYTE) *in_stream.data++;
 +    }
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h
+--- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,62 @@
 +#ifndef __IINOUTSTREAMS_H
 +#define __IINOUTSTREAMS_H
@@ -36375,9 +36372,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squa
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-tools-patched/LZMA/lzmalt/LenCoder.h
---- squashfs-tools/LZMA/lzmalt/LenCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-tools-patched/LZMA/lzmalt/LenCoder.h
+--- squashfs-tools/LZMA/lzmalt/LenCoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,75 @@
 +#ifndef __LENCODER_H
 +#define __LENCODER_H
@@ -36454,9 +36451,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h
---- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h
+--- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,146 @@
 +#ifndef __LITERALCODER_H
 +#define __LITERALCODER_H
@@ -36604,9 +36601,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squas
 +  }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c
+--- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,417 @@
 +#include "Portable.h"
 +#include "stdio.h"
@@ -37025,9 +37022,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squash
 +  return S_OK;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h
+--- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,60 @@
 +#ifndef __LZARITHMETIC_DECODER_H
 +#define __LZARITHMETIC_DECODER_H
@@ -37089,9 +37086,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squash
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tools-patched/LZMA/lzmalt/LZMA.h
---- squashfs-tools/LZMA/lzmalt/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tools-patched/LZMA/lzmalt/LZMA.h
+--- squashfs-tools/LZMA/lzmalt/LZMA.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2021-04-15 21:24:17.093867578 -0700
 @@ -0,0 +1,83 @@
 +#include "LenCoder.h"
 +
@@ -37176,9 +37173,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tool
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-tools-patched/LZMA/lzmalt/lzmalt.h
---- squashfs-tools/LZMA/lzmalt/lzmalt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-tools-patched/LZMA/lzmalt/lzmalt.h
+--- squashfs-tools/LZMA/lzmalt/lzmalt.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2021-04-15 21:24:17.094867593 -0700
 @@ -0,0 +1,16 @@
 +#ifndef __7Z_H
 +#define __7Z_H
@@ -37196,9 +37193,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-to
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-tools-patched/LZMA/lzmalt/Makefile
---- squashfs-tools/LZMA/lzmalt/Makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-tools-patched/LZMA/lzmalt/Makefile
+--- squashfs-tools/LZMA/lzmalt/Makefile	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2021-04-15 21:24:17.094867593 -0700
 @@ -0,0 +1,10 @@
 +INCLUDEDIR = .
 +
@@ -37210,9 +37207,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-to
 +
 +clean :
 +	rm -f *.o
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-tools-patched/LZMA/lzmalt/Portable.h
---- squashfs-tools/LZMA/lzmalt/Portable.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-tools-patched/LZMA/lzmalt/Portable.h
+--- squashfs-tools/LZMA/lzmalt/Portable.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2021-04-15 21:24:17.094867593 -0700
 @@ -0,0 +1,59 @@
 +#ifndef __PORTABLE_H
 +#define __PORTABLE_H
@@ -37273,9 +37270,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-
 +#define RETURN_IF_NOT_S_OK(x) { HRESULT __aResult_ = (x); if(__aResult_ != S_OK) return __aResult_; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h
---- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h
+--- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2021-04-15 21:24:17.094867593 -0700
 @@ -0,0 +1,56 @@
 +#ifndef __COMPRESSION_RANGECODER_H
 +#define __COMPRESSION_RANGECODER_H
@@ -37333,9 +37330,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashf
 +  }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-tools-patched/LZMA/lzmalt/RCDefs.h
---- squashfs-tools/LZMA/lzmalt/RCDefs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-tools-patched/LZMA/lzmalt/RCDefs.h
+--- squashfs-tools/LZMA/lzmalt/RCDefs.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2021-04-15 21:24:17.094867593 -0700
 @@ -0,0 +1,43 @@
 +#ifndef __RCDEFS_H
 +#define __RCDEFS_H
@@ -37380,9 +37377,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-to
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h
---- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h
+--- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2021-04-15 21:24:17.094867593 -0700
 @@ -0,0 +1,289 @@
 +/* vxTypesOld.h - old VxWorks type definition header */
 +
@@ -37673,9 +37670,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashf
 +#endif
 +
 +#endif /* __INCvxTypesOldh */
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs-tools-patched/LZMA/lzmalt/WindowOut.h
---- squashfs-tools/LZMA/lzmalt/WindowOut.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs-tools-patched/LZMA/lzmalt/WindowOut.h
+--- squashfs-tools/LZMA/lzmalt/WindowOut.h	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2021-04-15 21:24:17.094867593 -0700
 @@ -0,0 +1,52 @@
 +#ifndef __STREAM_WINDOWOUT_H
 +#define __STREAM_WINDOWOUT_H
@@ -37729,9 +37726,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-patched/lzma_wrapper.c
---- squashfs-tools/lzma_wrapper.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/lzma_wrapper.c	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-patched/lzma_wrapper.c
+--- squashfs-tools/lzma_wrapper.c	2021-04-15 22:58:59.993587676 -0700
++++ squashfs-tools-patched/lzma_wrapper.c	2021-04-15 21:24:17.094867593 -0700
 @@ -27,14 +27,21 @@
  #include "squashfs_fs.h"
  #include "compressor.h"
@@ -38076,11 +38073,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
 +	.supported = 1
 +};
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/Makefile
---- squashfs-tools/Makefile	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/Makefile	2016-08-25 09:06:03.223530354 -0400
-@@ -26,7 +26,7 @@
- # To build using XZ Utils liblzma - install the library and uncomment
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/Makefile
+--- squashfs-tools/Makefile	2021-04-15 22:58:59.992587662 -0700
++++ squashfs-tools-patched/Makefile	2021-04-15 21:26:13.529653924 -0700
+@@ -30,7 +30,7 @@
+ # To build install the library and uncomment
  # the XZ_SUPPORT line below.
  #
 -#XZ_SUPPORT = 1
@@ -38088,16 +38085,16 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  
  
  ############ Building LZO support ##############
-@@ -37,7 +37,7 @@
- # LZO_SUPPORT line below. If needed, uncomment and set LZO_DIR to the
- # installation prefix.
+@@ -44,7 +44,7 @@
+ # To build install the library and uncomment
+ # the XZ_SUPPORT line below.
  #
 -#LZO_SUPPORT = 1
 +LZO_SUPPORT = 1
- #LZO_DIR = /usr/local
  
  
-@@ -72,8 +72,13 @@
+ ########### Building LZ4 support #############
+@@ -141,8 +141,13 @@
  # and uncomment the LZMA_SUPPORT line below.
  #
  #LZMA_XZ_SUPPORT = 1
@@ -38111,11 +38108,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
 +LZMA_ALT_DIR = $(LZMA_BASE_DIR)/lzmalt
 +LZMA_ADAPT_DIR = $(LZMA_BASE_DIR)/lzmadaptive/C/7zip/Compress/LZMA_Lib
  
- ######## Specifying default compression ########
- #
-@@ -117,10 +122,11 @@
+ ###############################################
+ #        End of BUILD options section         #
+@@ -158,10 +163,11 @@
  UNSQUASHFS_OBJS = unsquashfs.o unsquash-1.o unsquash-2.o unsquash-3.o \
- 	unsquash-4.o swap.o compressor.o unsquashfs_info.o
+ 	unsquash-4.o unsquash-123.o unsquash-34.o swap.o compressor.o unsquashfs_info.o
  
 -CFLAGS ?= -O2
 +# CJH: Added -g, -Werror and -DSQUASHFS_TRACE
@@ -38127,7 +38124,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  
  LIBS = -lpthread -lm
  ifeq ($(GZIP_SUPPORT),1)
-@@ -132,13 +138,18 @@
+@@ -173,13 +179,18 @@
  endif
  
  ifeq ($(LZMA_SUPPORT),1)
@@ -38147,7 +38144,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  endif
  
  ifeq ($(LZMA_XZ_SUPPORT),1)
-@@ -222,10 +233,12 @@
+@@ -278,10 +289,12 @@
  endif
  
  .PHONY: all
@@ -38162,7 +38159,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  
  mksquashfs.o: Makefile mksquashfs.c squashfs_fs.h squashfs_swap.h mksquashfs.h \
  	sort.h pseudo.h compressor.h xattr.h action.h error.h progressbar.h \
-@@ -265,7 +278,8 @@
+@@ -321,7 +334,8 @@
  
  gzip_wrapper.o: gzip_wrapper.c squashfs_fs.h gzip_wrapper.h compressor.h
  
@@ -38172,7 +38169,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  
  lzma_xz_wrapper.o: lzma_xz_wrapper.c compressor.h squashfs_fs.h
  
-@@ -275,8 +289,13 @@
+@@ -331,8 +345,13 @@
  
  xz_wrapper.o: xz_wrapper.c squashfs_fs.h xz_wrapper.h compressor.h
  
@@ -38187,7 +38184,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  
  unsquashfs.o: unsquashfs.h unsquashfs.c squashfs_fs.h squashfs_swap.h \
  	squashfs_compat.h xattr.h read_fs.h compressor.h
-@@ -294,12 +313,22 @@
+@@ -354,12 +373,22 @@
  
  unsquashfs_info.o: unsquashfs.h squashfs_fs.h
  
@@ -38214,10 +38211,10 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
 -	cp mksquashfs $(INSTALL_DIR)
 -	cp unsquashfs $(INSTALL_DIR)
 +	cp sasquatch $(INSTALL_DIR)
-diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-tools-patched/process_fragments.c
---- squashfs-tools/process_fragments.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/process_fragments.c	2016-08-25 09:06:03.223530354 -0400
-@@ -192,9 +192,10 @@
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-tools-patched/process_fragments.c
+--- squashfs-tools/process_fragments.c	2021-04-15 22:58:59.994587690 -0700
++++ squashfs-tools-patched/process_fragments.c	2021-04-15 21:24:17.095867609 -0700
+@@ -193,9 +193,10 @@
  
  		res = compressor_uncompress(comp, buffer->data, data, size,
  			block_size, &error);
@@ -38231,9 +38228,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-too
  	} else if(compressed_buffer)
  		memcpy(buffer->data, compressed_buffer->data, size);
  	else {
-diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched/read_fs.c
---- squashfs-tools/read_fs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/read_fs.c	2016-08-25 09:06:03.231530353 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched/read_fs.c
+--- squashfs-tools/read_fs.c	2021-04-15 22:58:59.995587704 -0700
++++ squashfs-tools-patched/read_fs.c	2021-04-15 21:24:17.095867609 -0700
 @@ -87,8 +87,9 @@
  		res = compressor_uncompress(comp, block, buffer, c_byte,
  			outlen, &error);
@@ -38246,23 +38243,23 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched
  			return 0;
  		}
  	} else {
-diff --strip-trailing-cr -NBbaur squashfs-tools/README.md squashfs-tools-patched/README.md
---- squashfs-tools/README.md	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/README.md	2016-08-25 09:06:03.223530354 -0400
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/README.md squashfs-tools-patched/README.md
+--- squashfs-tools/README.md	1969-12-31 16:00:00.000000000 -0800
++++ squashfs-tools-patched/README.md	2021-04-15 21:24:17.095867609 -0700
 @@ -0,0 +1,2 @@
 +This is the raw, patched source code for squashfs-tools. It is included in this repository for documentation and administrative purposes only. Any bugs or patches not directly related to the modifications made by the sasquatch patches should be reported to the squashfs-tools project.
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-patched/squashfs_fs.h
---- squashfs-tools/squashfs_fs.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/squashfs_fs.h	2016-08-25 09:06:03.223530354 -0400
-@@ -277,6 +277,22 @@
- #define LZO_COMPRESSION		3
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-patched/squashfs_fs.h
+--- squashfs-tools/squashfs_fs.h	2021-04-15 22:58:59.996587718 -0700
++++ squashfs-tools-patched/squashfs_fs.h	2021-04-15 21:27:23.483719397 -0700
+@@ -285,6 +285,22 @@
  #define XZ_COMPRESSION		4
  #define LZ4_COMPRESSION		5
+ #define ZSTD_COMPRESSION	6
 +// CJH: Added #defines for additional decompressors
-+#define LZMA_WRT_COMPRESSION        6
-+#define LZMA_ADAPTIVE_COMPRESSION   7
-+#define LZMA_ALT_COMPRESSION        8
++#define LZMA_WRT_COMPRESSION        7
++#define LZMA_ADAPTIVE_COMPRESSION   8
++#define LZMA_ALT_COMPRESSION        9
 +
 +// CJH: A generic super block structure used for auto-detecting endianess
 +#include <stdint.h>
@@ -38278,7 +38275,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-pat
  
  struct squashfs_super_block {
  	unsigned int		s_magic;
-@@ -488,4 +504,21 @@
+@@ -496,4 +512,21 @@
  	unsigned int		unused;
  };
  
@@ -38300,43 +38297,35 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-pat
 +};
 +
  #endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
---- squashfs-tools/unsquashfs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/unsquashfs.c	2016-08-25 09:06:03.223530354 -0400
-@@ -32,7 +32,8 @@
- #include "stdarg.h"
-
- #include <sys/sysinfo.h>
- #include <sys/types.h>
-+#include <sys/sysmacros.h>
- #include <sys/time.h>
- #include <sys/resource.h>
- #include <limits.h>
-@@ -44,13 +44,19 @@
- pthread_mutex_t	fragment_mutex;
+diff '--exclude=.git' --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
+--- squashfs-tools/unsquashfs.c	2021-04-15 22:58:59.997587732 -0700
++++ squashfs-tools-patched/unsquashfs.c	2021-04-15 22:49:53.491001565 -0700
+@@ -47,14 +47,21 @@
+ static long long start_offset = 0;
  
  /* user options that control parallelisation */
 -int processors = -1;
-+//int processors = -1;
++// int processors = -1;
 +// CJH: Temporarily set the default processor count to 1 to prevent threading bug
 +//      until a proper fix is implemented.
 +int processors = 1;
  
  struct super_block sBlk;
- squashfs_operations s_ops;
+ squashfs_operations *s_ops;
+ squashfs_operations *(*read_filesystem_tables)();
 -struct compressor *comp;
--
--int bytes = 0, swap, file_count = 0, dir_count = 0, sym_count = 0,
 +// CJH: Initialize to NULL
 +struct compressor *comp = NULL;
 +// CJH: Add override struct
 +struct override_table override = { 0 };
 +// CJH: Initialize swap to -1
+ 
+-int bytes = 0, swap, file_count = 0, dir_count = 0, sym_count = 0,
 +int bytes = 0, swap = -1, file_count = 0, dir_count = 0, sym_count = 0,
  	dev_count = 0, fifo_count = 0;
- char *inode_table = NULL, *directory_table = NULL;
  struct hash_table_entry *inode_table_hash[65536], *directory_table_hash[65536];
-@@ -701,8 +707,9 @@
+ int fd;
+@@ -714,8 +721,9 @@
  			outlen, &error);
  
  		if(res == -1) {
@@ -38348,31 +38337,19 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  			goto failed;
  		}
  	} else {
-@@ -720,7 +727,10 @@
+@@ -733,7 +741,10 @@
  	 * is of the expected size
  	 */
  	if(expected && expected != res)
 +    {
 +        ERROR("Decompressed size did not match the expected size! [%d != %d]\n", res, expected);
- 		return 0;
+ 		return FALSE;
 +    }
  	else
  		return res;
  
-@@ -747,8 +757,9 @@
- 			block_size, &error);
- 
- 		if(res == -1) {
--			ERROR("%s uncompress failed with error code %d\n",
--				comp->name, error);
-+            // CJH: Compression errors are displayed elsewhere
-+			//ERROR("%s uncompress failed with error code %d\n",
-+			//	comp->name, error);
- 			goto failed;
- 		}
- 
-@@ -1622,7 +1633,7 @@
- 	dir_count ++;
+@@ -1685,7 +1696,7 @@
+ 	return scan_res;
  }
  
 -
@@ -38380,21 +38357,21 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  void squashfs_stat(char *source)
  {
  	time_t mkfs_time = (time_t) sBlk.s.mkfs_time;
-@@ -1640,9 +1651,10 @@
+@@ -1704,9 +1715,10 @@
  
  	printf("Creation or last append time %s", mkfs_str ? mkfs_str :
  		"failed to get time\n");
--	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n",
--		sBlk.s.bytes_used / 1024.0, sBlk.s.bytes_used /
--		(1024.0 * 1024.0));
-+    // CJH: Added bytes output
-+	printf("Filesystem size %.2f Kbytes (%.2f Mbytes) (%lld [0x%llX] bytes)\n",
-+		(sBlk.s.bytes_used / 1024.0), (sBlk.s.bytes_used / (1024.0 * 1024.0)), 
-+        sBlk.s.bytes_used, sBlk.s.bytes_used);
+-	printf("Filesystem size %llu bytes (%.2f Kbytes / %.2f Mbytes)\n",
+-		sBlk.s.bytes_used, sBlk.s.bytes_used / 1024.0,
+-		sBlk.s.bytes_used / (1024.0 * 1024.0));
++     // CJH: Added bytes output
++ 	printf("Filesystem size %.2f Kbytes (%.2f Mbytes) (%lld [0x%llX] bytes)\n",
++ 		(sBlk.s.bytes_used / 1024.0), (sBlk.s.bytes_used / (1024.0 * 1024.0)),
++                 sBlk.s.bytes_used, sBlk.s.bytes_used);
  
  	if(sBlk.s.s_major == 4) {
  		printf("Compression %s\n", comp->name);
-@@ -1714,25 +1726,25 @@
+@@ -1788,25 +1800,25 @@
  		printf("Number of gids %d\n", sBlk.no_guids);
  	}
  
@@ -38428,22 +38405,22 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	}
  }
  
-@@ -1745,9 +1757,11 @@
+@@ -1819,9 +1831,11 @@
  	if(!comp->supported) {
  		ERROR("Filesystem uses %s compression, this is "
  			"unsupported by this version\n", comp->name);
 -		ERROR("Decompressors available:\n");
 -		display_compressors("", "");
--		return 0;
+-		return FALSE;
 +        // CJH: Try to continue anyway
-+		//ERROR("Decompressors available:\n");
-+		//display_compressors("", "");
-+		//return 0;
-+        return 1;
++		// ERROR("Decompressors available:\n");
++		// display_compressors("", "");
++		// return FALSE;
++		return 1;
  	}
  
  	/*
-@@ -1777,17 +1791,74 @@
+@@ -1851,24 +1865,85 @@
  {
  	squashfs_super_block_3 sBlk_3;
  	struct squashfs_super_block sBlk_4;
@@ -38496,15 +38473,15 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	read_fs_bytes(fd, SQUASHFS_START, sizeof(struct squashfs_super_block),
  		&sBlk_4);
 -	swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
-+	// CJH: swap detection already done generically above
-+    //swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
++ 	// CJH: swap detection already done generically above
++	// swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
  	SQUASHFS_INSWAP_SUPER_BLOCK(&sBlk_4);
  
 +    /*
 +     * CJH: Don't consider it an error if SQUASHFS_MAGIC doesn't match
  	if(sBlk_4.s_magic == SQUASHFS_MAGIC && sBlk_4.s_major == 4 &&
  			sBlk_4.s_minor == 0) {
-+     */
++    */
 +
 +     // CJH: Added s_major override
 +     if((sBlk_4.s_major == 4 && sBlk_4.s_minor == 0) ||
@@ -38516,10 +38493,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 +        if(override.s_minor)
 +            sBlk_4.s_minor = override.s_minor;
 +
- 		s_ops.squashfs_opendir = squashfs_opendir_4;
- 		s_ops.read_fragment = read_fragment_4;
- 		s_ops.read_fragment_table = read_fragment_table_4;
-@@ -1799,7 +1870,11 @@
+ 		read_filesystem_tables = read_filesystem_tables_4;
+ 		memcpy(&sBlk, &sBlk_4, sizeof(sBlk_4));
+ 
  		/*
  		 * Check the compression type
  		 */
@@ -38531,7 +38507,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		return TRUE;
  	}
  
-@@ -1813,6 +1888,9 @@
+@@ -1882,6 +1957,9 @@
  	/*
  	 * Check it is a SQUASHFS superblock
  	 */
@@ -38541,7 +38517,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	swap = 0;
  	if(sBlk_3.s_magic != SQUASHFS_MAGIC) {
  		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP) {
-@@ -1828,6 +1906,13 @@
+@@ -1897,6 +1975,13 @@
  			goto failed_mount;
  		}
  	}
@@ -38555,7 +38531,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  
  	sBlk.s.s_magic = sBlk_3.s_magic;
  	sBlk.s.inodes = sBlk_3.inodes;
-@@ -1850,14 +1935,22 @@
+@@ -1919,14 +2004,22 @@
  	sBlk.guid_start = sBlk_3.guid_start;
  	sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
  
@@ -38579,7 +38555,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		if(sBlk.s.s_major == 1) {
  			sBlk.s.block_size = sBlk_3.block_size_1;
  			sBlk.s.fragment_table_start = sBlk.uid_start;
-@@ -1893,7 +1986,11 @@
+@@ -1948,7 +2041,11 @@
  	/*
  	 * 1.x, 2.x and 3.x filesystems use gzip compression.
  	 */
@@ -38591,7 +38567,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	return TRUE;
  
  failed_mount:
-@@ -2106,11 +2203,15 @@
+@@ -2167,11 +2264,15 @@
  			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size), block_size,
  			&error);
  
@@ -38607,9 +38583,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  
  		/*
  		 * block has been either successfully decompressed, or an error
-@@ -2505,6 +2606,9 @@
- 	int fragment_buffer_size = FRAGMENT_BUFFER_DEFAULT;
- 	int data_buffer_size = DATA_BUFFER_DEFAULT;
+@@ -2639,6 +2740,9 @@
+ 	long res;
+ 	int exit_code = 0;
  
 +    // CJH: Initialize verbosity to FALSE
 +    verbose = FALSE;
@@ -38617,10 +38593,12 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	pthread_mutex_init(&screen_mutex, NULL);
  	root_process = geteuid() == 0;
  	if(root_process)
-@@ -2611,6 +2715,83 @@
- 		} else if(strcmp(argv[i], "-regex") == 0 ||
- 				strcmp(argv[i], "-r") == 0)
- 			use_regex = TRUE;
+@@ -2776,7 +2880,85 @@
+ 				ERROR("%s: %s missing or invalid offset size\n", argv[0], argv[i - 1]);
+ 				exit(1);
+ 			}
+-		} else
++		}
 +        // CJH: Added -comp, -be, -le, -major, -minor options
 +        else if(strcmp(argv[i], "-c") == 0 ||
 +                strcmp(argv[i], "-comp") == 0) {
@@ -38698,10 +38676,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 +#endif
 +        else if(strcmp(argv[i], "-trace") == 0)
 +            verbose = TRUE;
- 		else
++		else
  			goto options;
  	}
-@@ -2674,6 +2855,22 @@
+ 
+@@ -2859,6 +3041,22 @@
  				"regular expressions\n");
  			ERROR("\t\t\t\trather than use the default shell "
  				"wildcard\n\t\t\t\texpansion (globbing)\n");


### PR DESCRIPTION
This was basically done by hand by updating the rejected hunks. Indenting might be messed up (good thing C isn't whitespace-sensitive). Any testing / validation appreciated.

---

Closes #33.

EDIT: Something to note: the `#define` issue raised in the above issue I addressed by bumping the `#define`s by 1 to make room for the new ZSTD one. I don't know how this could potentially impact things. If that could make bad things happen, I'll need to revisit that part.