### PR TITLE
patches/patch0.txt: fix build on -fno-common toolchains

### DIFF
--- a/patches/patch0.txt
+++ b/patches/patch0.txt
@@ -147,7 +147,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/e
  
 -#ifdef SQUASHFS_TRACE
 +// CJH: Updated so that TRACE prints if -verbose is specified on the command line
-+int verbose;
++extern int verbose;
 +//#ifdef SQUASHFS_TRACE
  #define TRACE(s, args...) \
  		do { \
@@ -38312,9 +38312,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  #include <sys/time.h>
  #include <sys/resource.h>
  #include <limits.h>
-@@ -44,13 +44,19 @@
+@@ -44,13 +44,21 @@
  pthread_mutex_t	fragment_mutex;
  
++int verbose;
++
  /* user options that control parallelisation */
 -int processors = -1;
 +//int processors = -1;


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) sasquatch build fails as:

    c++   ./LZMA/lzmalt/*.o unsquashfs.o ... -o sasquatch
    ld: unsquash-1.o:squashfs-tools/error.h:34:
      multiple definition of `verbose'; unsquashfs.o:squashfs-tools/error.h:34: first defined here

gcc-10 will changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678.

The change splits declaration and definition.