### PR TITLE
Containerised build environment (Ubuntu 24.04 + squashfs-tools 4.4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:24.04 AS builder
+
+RUN --mount=type=cache,target=/var/cache/apt,id=builder-apt-cache \
+    --mount=type=cache,target=/var/lib/apt,id=builder-apt-lib \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        liblzma-dev \
+        liblzo2-dev \
+        patch \
+        zlib1g-dev \
+    && mkdir -p /sasquatch
+
+WORKDIR /sasquatch
+
+ADD https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.4/squashfs4.4.tar.gz .
+RUN tar -zxvf squashfs4.4.tar.gz
+
+COPY patches /sasquatch/patches
+RUN patch -d squashfs4.4 -p1 < patches/0_sasquatch_4.4.patch && \
+    patch -d squashfs4.4 -p1 < patches/1_fix_dangling_pointer.patch && \
+   cd squashfs4.4/squashfs-tools && \
+   make
+
+FROM ubuntu:24.04
+
+RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt-cache \
+    --mount=type=cache,target=/var/lib/apt,id=runtime-apt-lib \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+       liblzma5 \
+       liblzo2-2 \
+       zlib1g
+
+COPY --from=builder /sasquatch/squashfs4.4/squashfs-tools/sasquatch /usr/local/bin/sasquatch
+
+WORKDIR /work
+
+ENTRYPOINT [ "/usr/local/bin/sasquatch" ]

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script to download squashfs-tools v4.3, apply the patches, perform a clean build, and install.
+# Script to download squashfs-tools v4.4, apply the patches, perform a clean build, and install.
 
 # If not root, perform 'make install' with sudo
 if [ $UID -eq 0 ]
@@ -18,20 +18,20 @@ fi
 # Make sure we're working in the same directory as the build.sh script
 cd $(dirname `readlink  -f $0`)
 
-# Download squashfs4.3.tar.gz if it does not already exist
-if [ ! -e squashfs4.3.tar.gz ]
+# Download squashfs4.4.tar.gz if it does not already exist
+if [ ! -e squashfs4.4.tar.gz ]
 then
-    wget https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.3/squashfs4.3.tar.gz
+    wget https://downloads.sourceforge.net/project/squashfs/squashfs/squashfs4.4/squashfs4.4.tar.gz
 fi
 
-# Remove any previous squashfs4.3 directory to ensure a clean patch/build
-rm -rf squashfs4.3
+# Remove any previous squashfs4.4 directory to ensure a clean patch/build
+rm -rf squashfs4.4
 
-# Extract squashfs4.3.tar.gz
-tar -zxvf squashfs4.3.tar.gz
+# Extract squashfs4.4.tar.gz
+tar -zxvf squashfs4.4.tar.gz
 
 # Patch, build, and install the source
-cd squashfs4.3
-patch -p0 < ../patches/patch0.txt
+cd squashfs4.4
+patch -p1 < ../patches/*.patch
 cd squashfs-tools
 make && $SUDO make install

--- a/patches/0_sasquatch_4.4.patch
+++ b/patches/0_sasquatch_4.4.patch
@@ -1,513 +1,8 @@
-diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patched/compressor.c
---- squashfs-tools/compressor.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.c	2016-08-25 09:06:03.223530354 -0400
-@@ -25,6 +25,9 @@
- #include "compressor.h"
- #include "squashfs_fs.h"
- 
-+// CJH: Added these includes
-+#include "error.h"
-+
- #ifndef GZIP_SUPPORT
- static struct compressor gzip_comp_ops =  {
- 	ZLIB_COMPRESSION, "gzip"
-@@ -65,6 +68,9 @@
- extern struct compressor xz_comp_ops;
- #endif
- 
-+extern struct compressor lzma_alt_comp_ops;
-+extern struct compressor lzma_wrt_comp_ops;
-+extern struct compressor lzma_adaptive_comp_ops;
- 
- static struct compressor unknown_comp_ops = {
- 	0, "unknown"
-@@ -74,6 +80,10 @@
- struct compressor *compressor[] = {
- 	&gzip_comp_ops,
- 	&lzma_comp_ops,
-+    // CJH: Added additional LZMA decompressors. Order is intentional.
-+    &lzma_adaptive_comp_ops,
-+    &lzma_alt_comp_ops,
-+    &lzma_wrt_comp_ops,
- 	&lzo_comp_ops,
- 	&lz4_comp_ops,
- 	&xz_comp_ops,
-@@ -81,6 +91,19 @@
- };
- 
- 
-+int lookup_compressor_index(char *name)
-+{
-+    int i;
-+
-+    for(i = 0; compressor[i]->id; i++)
-+    {
-+        if(strcmp(name, compressor[i]->name) == 0)
-+            return i;
-+    }
-+
-+    return -1;
-+}
-+
- struct compressor *lookup_compressor(char *name)
- {
- 	int i;
-@@ -135,3 +158,67 @@
- 					compressor[i]->name, str);
- 		}
- }
-+
-+// CJH: calls the currently selected decompressor, unless that fails, then tries the other decompressors
-+int detected_compressor_index = 0;
-+int compressor_uncompress(struct compressor *comp, void *dest, void *src, int size, int block_size, int *error)
-+{
-+    int i = 0, retval = -1, default_compressor_id = -1;
-+
-+    if(detected_compressor_index)
-+    {
-+        retval = compressor[detected_compressor_index]->uncompress(dest, src, size, block_size, error);
-+    }
-+
-+    if(retval < 1 && comp->uncompress)
-+    {
-+        if(!detected_compressor_index) ERROR("Trying to decompress using default %s decompressor...\n", comp->name);
-+        
-+        retval = comp->uncompress(dest, src, size, block_size, error);
-+        
-+        if(!detected_compressor_index)
-+        {
-+            if(retval > 0)
-+            {
-+                ERROR("Successfully decompressed with default %s decompressor\n", comp->name);
-+                detected_compressor_index = lookup_compressor_index(comp->name);
-+            }
-+            else
-+            {
-+                TRACE("Default %s decompressor failed! [%d %d]\n", comp->name, retval, *error);
-+            }
-+        }
-+    }
-+
-+    if(retval < 1)
-+    {
-+        default_compressor_id = comp->id;
-+
-+        for(i=0; compressor[i]->id; i++)
-+        {
-+            comp = compressor[i];
-+            
-+            if(comp->id != default_compressor_id && 
-+               comp->id != compressor[detected_compressor_index]->id && 
-+               comp->uncompress)
-+            {
-+                ERROR("Trying to decompress with %s...\n", comp->name);
-+                retval = comp->uncompress(dest, src, size, block_size, error);
-+                if(retval > 0)
-+                {
-+                    //TRACE("%s decompressor succeeded!\n", comp->name);
-+                    ERROR("Detected %s compression\n", comp->name);
-+                    detected_compressor_index = i;
-+                    break;
-+                }
-+                else
-+                {
-+                    TRACE("%s decompressor failed! [%d %d]\n", comp->name, retval, *error);
-+                }
-+            }
-+        }
-+    }
-+
-+    return retval;
-+}
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patched/compressor.h
---- squashfs-tools/compressor.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.h	2016-08-25 09:06:03.223530354 -0400
-@@ -59,11 +59,14 @@
- }
- 
- 
-+/* CJH: Needed more logic for compression auto-detection, no longer inlined
- static inline int compressor_uncompress(struct compressor *comp, void *dest,
- 	void *src, int size, int block_size, int *error)
- {
- 	return comp->uncompress(dest, src, size, block_size, error);
- }
-+*/
-+int compressor_uncompress(struct compressor *comp, void *dest, void *src, int size, int block_size, int *error);
- 
- 
- /*
-diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
---- squashfs-tools/error.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/error.h	2016-08-25 09:06:03.223530354 -0400
-@@ -30,14 +30,18 @@
- extern void progressbar_error(char *fmt, ...);
- extern void progressbar_info(char *fmt, ...);
- 
--#ifdef SQUASHFS_TRACE
-+// CJH: Updated so that TRACE prints if -verbose is specified on the command line
-+int verbose;
-+//#ifdef SQUASHFS_TRACE
- #define TRACE(s, args...) \
- 		do { \
--			progressbar_info("squashfs: "s, ## args);\
-+			if(verbose) progressbar_info("squashfs: "s, ## args);\
- 		} while(0)
-+/*
- #else
- #define TRACE(s, args...)
- #endif
-+*/
- 
- #define INFO(s, args...) \
- 		do {\
-diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/LICENSE
---- squashfs-tools/LICENSE	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LICENSE	2016-08-25 09:06:03.223530354 -0400
-@@ -0,0 +1,339 @@
-+                    GNU GENERAL PUBLIC LICENSE
-+                       Version 2, June 1991
-+
-+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
-+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-+ Everyone is permitted to copy and distribute verbatim copies
-+ of this license document, but changing it is not allowed.
-+
-+                            Preamble
-+
-+  The licenses for most software are designed to take away your
-+freedom to share and change it.  By contrast, the GNU General Public
-+License is intended to guarantee your freedom to share and change free
-+software--to make sure the software is free for all its users.  This
-+General Public License applies to most of the Free Software
-+Foundation's software and to any other program whose authors commit to
-+using it.  (Some other Free Software Foundation software is covered by
-+the GNU Lesser General Public License instead.)  You can apply it to
-+your programs, too.
-+
-+  When we speak of free software, we are referring to freedom, not
-+price.  Our General Public Licenses are designed to make sure that you
-+have the freedom to distribute copies of free software (and charge for
-+this service if you wish), that you receive source code or can get it
-+if you want it, that you can change the software or use pieces of it
-+in new free programs; and that you know you can do these things.
-+
-+  To protect your rights, we need to make restrictions that forbid
-+anyone to deny you these rights or to ask you to surrender the rights.
-+These restrictions translate to certain responsibilities for you if you
-+distribute copies of the software, or if you modify it.
-+
-+  For example, if you distribute copies of such a program, whether
-+gratis or for a fee, you must give the recipients all the rights that
-+you have.  You must make sure that they, too, receive or can get the
-+source code.  And you must show them these terms so they know their
-+rights.
-+
-+  We protect your rights with two steps: (1) copyright the software, and
-+(2) offer you this license which gives you legal permission to copy,
-+distribute and/or modify the software.
-+
-+  Also, for each author's protection and ours, we want to make certain
-+that everyone understands that there is no warranty for this free
-+software.  If the software is modified by someone else and passed on, we
-+want its recipients to know that what they have is not the original, so
-+that any problems introduced by others will not reflect on the original
-+authors' reputations.
-+
-+  Finally, any free program is threatened constantly by software
-+patents.  We wish to avoid the danger that redistributors of a free
-+program will individually obtain patent licenses, in effect making the
-+program proprietary.  To prevent this, we have made it clear that any
-+patent must be licensed for everyone's free use or not licensed at all.
-+
-+  The precise terms and conditions for copying, distribution and
-+modification follow.
-+
-+                    GNU GENERAL PUBLIC LICENSE
-+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-+
-+  0. This License applies to any program or other work which contains
-+a notice placed by the copyright holder saying it may be distributed
-+under the terms of this General Public License.  The "Program", below,
-+refers to any such program or work, and a "work based on the Program"
-+means either the Program or any derivative work under copyright law:
-+that is to say, a work containing the Program or a portion of it,
-+either verbatim or with modifications and/or translated into another
-+language.  (Hereinafter, translation is included without limitation in
-+the term "modification".)  Each licensee is addressed as "you".
-+
-+Activities other than copying, distribution and modification are not
-+covered by this License; they are outside its scope.  The act of
-+running the Program is not restricted, and the output from the Program
-+is covered only if its contents constitute a work based on the
-+Program (independent of having been made by running the Program).
-+Whether that is true depends on what the Program does.
-+
-+  1. You may copy and distribute verbatim copies of the Program's
-+source code as you receive it, in any medium, provided that you
-+conspicuously and appropriately publish on each copy an appropriate
-+copyright notice and disclaimer of warranty; keep intact all the
-+notices that refer to this License and to the absence of any warranty;
-+and give any other recipients of the Program a copy of this License
-+along with the Program.
-+
-+You may charge a fee for the physical act of transferring a copy, and
-+you may at your option offer warranty protection in exchange for a fee.
-+
-+  2. You may modify your copy or copies of the Program or any portion
-+of it, thus forming a work based on the Program, and copy and
-+distribute such modifications or work under the terms of Section 1
-+above, provided that you also meet all of these conditions:
-+
-+    a) You must cause the modified files to carry prominent notices
-+    stating that you changed the files and the date of any change.
-+
-+    b) You must cause any work that you distribute or publish, that in
-+    whole or in part contains or is derived from the Program or any
-+    part thereof, to be licensed as a whole at no charge to all third
-+    parties under the terms of this License.
-+
-+    c) If the modified program normally reads commands interactively
-+    when run, you must cause it, when started running for such
-+    interactive use in the most ordinary way, to print or display an
-+    announcement including an appropriate copyright notice and a
-+    notice that there is no warranty (or else, saying that you provide
-+    a warranty) and that users may redistribute the program under
-+    these conditions, and telling the user how to view a copy of this
-+    License.  (Exception: if the Program itself is interactive but
-+    does not normally print such an announcement, your work based on
-+    the Program is not required to print an announcement.)
-+
-+These requirements apply to the modified work as a whole.  If
-+identifiable sections of that work are not derived from the Program,
-+and can be reasonably considered independent and separate works in
-+themselves, then this License, and its terms, do not apply to those
-+sections when you distribute them as separate works.  But when you
-+distribute the same sections as part of a whole which is a work based
-+on the Program, the distribution of the whole must be on the terms of
-+this License, whose permissions for other licensees extend to the
-+entire whole, and thus to each and every part regardless of who wrote it.
-+
-+Thus, it is not the intent of this section to claim rights or contest
-+your rights to work written entirely by you; rather, the intent is to
-+exercise the right to control the distribution of derivative or
-+collective works based on the Program.
-+
-+In addition, mere aggregation of another work not based on the Program
-+with the Program (or with a work based on the Program) on a volume of
-+a storage or distribution medium does not bring the other work under
-+the scope of this License.
-+
-+  3. You may copy and distribute the Program (or a work based on it,
-+under Section 2) in object code or executable form under the terms of
-+Sections 1 and 2 above provided that you also do one of the following:
-+
-+    a) Accompany it with the complete corresponding machine-readable
-+    source code, which must be distributed under the terms of Sections
-+    1 and 2 above on a medium customarily used for software interchange; or,
-+
-+    b) Accompany it with a written offer, valid for at least three
-+    years, to give any third party, for a charge no more than your
-+    cost of physically performing source distribution, a complete
-+    machine-readable copy of the corresponding source code, to be
-+    distributed under the terms of Sections 1 and 2 above on a medium
-+    customarily used for software interchange; or,
-+
-+    c) Accompany it with the information you received as to the offer
-+    to distribute corresponding source code.  (This alternative is
-+    allowed only for noncommercial distribution and only if you
-+    received the program in object code or executable form with such
-+    an offer, in accord with Subsection b above.)
-+
-+The source code for a work means the preferred form of the work for
-+making modifications to it.  For an executable work, complete source
-+code means all the source code for all modules it contains, plus any
-+associated interface definition files, plus the scripts used to
-+control compilation and installation of the executable.  However, as a
-+special exception, the source code distributed need not include
-+anything that is normally distributed (in either source or binary
-+form) with the major components (compiler, kernel, and so on) of the
-+operating system on which the executable runs, unless that component
-+itself accompanies the executable.
-+
-+If distribution of executable or object code is made by offering
-+access to copy from a designated place, then offering equivalent
-+access to copy the source code from the same place counts as
-+distribution of the source code, even though third parties are not
-+compelled to copy the source along with the object code.
-+
-+  4. You may not copy, modify, sublicense, or distribute the Program
-+except as expressly provided under this License.  Any attempt
-+otherwise to copy, modify, sublicense or distribute the Program is
-+void, and will automatically terminate your rights under this License.
-+However, parties who have received copies, or rights, from you under
-+this License will not have their licenses terminated so long as such
-+parties remain in full compliance.
-+
-+  5. You are not required to accept this License, since you have not
-+signed it.  However, nothing else grants you permission to modify or
-+distribute the Program or its derivative works.  These actions are
-+prohibited by law if you do not accept this License.  Therefore, by
-+modifying or distributing the Program (or any work based on the
-+Program), you indicate your acceptance of this License to do so, and
-+all its terms and conditions for copying, distributing or modifying
-+the Program or works based on it.
-+
-+  6. Each time you redistribute the Program (or any work based on the
-+Program), the recipient automatically receives a license from the
-+original licensor to copy, distribute or modify the Program subject to
-+these terms and conditions.  You may not impose any further
-+restrictions on the recipients' exercise of the rights granted herein.
-+You are not responsible for enforcing compliance by third parties to
-+this License.
-+
-+  7. If, as a consequence of a court judgment or allegation of patent
-+infringement or for any other reason (not limited to patent issues),
-+conditions are imposed on you (whether by court order, agreement or
-+otherwise) that contradict the conditions of this License, they do not
-+excuse you from the conditions of this License.  If you cannot
-+distribute so as to satisfy simultaneously your obligations under this
-+License and any other pertinent obligations, then as a consequence you
-+may not distribute the Program at all.  For example, if a patent
-+license would not permit royalty-free redistribution of the Program by
-+all those who receive copies directly or indirectly through you, then
-+the only way you could satisfy both it and this License would be to
-+refrain entirely from distribution of the Program.
-+
-+If any portion of this section is held invalid or unenforceable under
-+any particular circumstance, the balance of the section is intended to
-+apply and the section as a whole is intended to apply in other
-+circumstances.
-+
-+It is not the purpose of this section to induce you to infringe any
-+patents or other property right claims or to contest validity of any
-+such claims; this section has the sole purpose of protecting the
-+integrity of the free software distribution system, which is
-+implemented by public license practices.  Many people have made
-+generous contributions to the wide range of software distributed
-+through that system in reliance on consistent application of that
-+system; it is up to the author/donor to decide if he or she is willing
-+to distribute software through any other system and a licensee cannot
-+impose that choice.
-+
-+This section is intended to make thoroughly clear what is believed to
-+be a consequence of the rest of this License.
-+
-+  8. If the distribution and/or use of the Program is restricted in
-+certain countries either by patents or by copyrighted interfaces, the
-+original copyright holder who places the Program under this License
-+may add an explicit geographical distribution limitation excluding
-+those countries, so that distribution is permitted only in or among
-+countries not thus excluded.  In such case, this License incorporates
-+the limitation as if written in the body of this License.
-+
-+  9. The Free Software Foundation may publish revised and/or new versions
-+of the General Public License from time to time.  Such new versions will
-+be similar in spirit to the present version, but may differ in detail to
-+address new problems or concerns.
-+
-+Each version is given a distinguishing version number.  If the Program
-+specifies a version number of this License which applies to it and "any
-+later version", you have the option of following the terms and conditions
-+either of that version or of any later version published by the Free
-+Software Foundation.  If the Program does not specify a version number of
-+this License, you may choose any version ever published by the Free Software
-+Foundation.
-+
-+  10. If you wish to incorporate parts of the Program into other free
-+programs whose distribution conditions are different, write to the author
-+to ask for permission.  For software which is copyrighted by the Free
-+Software Foundation, write to the Free Software Foundation; we sometimes
-+make exceptions for this.  Our decision will be guided by the two goals
-+of preserving the free status of all derivatives of our free software and
-+of promoting the sharing and reuse of software generally.
-+
-+                            NO WARRANTY
-+
-+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-+REPAIR OR CORRECTION.
-+
-+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-+POSSIBILITY OF SUCH DAMAGES.
-+
-+                     END OF TERMS AND CONDITIONS
-+
-+            How to Apply These Terms to Your New Programs
-+
-+  If you develop a new program, and you want it to be of the greatest
-+possible use to the public, the best way to achieve this is to make it
-+free software which everyone can redistribute and change under these terms.
-+
-+  To do so, attach the following notices to the program.  It is safest
-+to attach them to the start of each source file to most effectively
-+convey the exclusion of warranty; and each file should have at least
-+the "copyright" line and a pointer to where the full notice is found.
-+
-+    <one line to give the program's name and a brief idea of what it does.>
-+    Copyright (C) <year>  <name of author>
-+
-+    This program is free software; you can redistribute it and/or modify
-+    it under the terms of the GNU General Public License as published by
-+    the Free Software Foundation; either version 2 of the License, or
-+    (at your option) any later version.
-+
-+    This program is distributed in the hope that it will be useful,
-+    but WITHOUT ANY WARRANTY; without even the implied warranty of
-+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+    GNU General Public License for more details.
-+
-+    You should have received a copy of the GNU General Public License along
-+    with this program; if not, write to the Free Software Foundation, Inc.,
-+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-+
-+Also add information on how to contact you by electronic and paper mail.
-+
-+If the program is interactive, make it output a short notice like this
-+when it starts in an interactive mode:
-+
-+    Gnomovision version 69, Copyright (C) year name of author
-+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-+    This is free software, and you are welcome to redistribute it
-+    under certain conditions; type `show c' for details.
-+
-+The hypothetical commands `show w' and `show c' should show the appropriate
-+parts of the General Public License.  Of course, the commands you use may
-+be called something other than `show w' and `show c'; they could even be
-+mouse-clicks or menu items--whatever suits your program.
-+
-+You should also get your employer (if you work as a programmer) or your
-+school, if any, to sign a "copyright disclaimer" for the program, if
-+necessary.  Here is a sample; alter the names:
-+
-+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-+
-+  <signature of Ty Coon>, 1 April 1989
-+  Ty Coon, President of Vice
-+
-+This General Public License does not permit incorporating your program into
-+proprietary programs.  If your program is a subroutine library, you may
-+consider it more useful to permit linking proprietary applications with the
-+library.  If this is what you want to do, use the GNU Lesser General
-+Public License instead of this License.
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-tools-patched/LZMA/lzma465/7zC.txt
---- squashfs-tools/LZMA/lzma465/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/7zC.txt b/squashfs-tools/LZMA/lzma465/7zC.txt
+new file mode 100644
+index 0000000..5d5d06d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/7zC.txt
 @@ -0,0 +1,194 @@
 +7z ANSI-C Decoder 4.62
 +----------------------
@@ -703,9 +198,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-to
 +http://www.7-zip.org
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squashfs-tools-patched/LZMA/lzma465/7zFormat.txt
---- squashfs-tools/LZMA/lzma465/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/7zFormat.txt b/squashfs-tools/LZMA/lzma465/7zFormat.txt
+new file mode 100644
+index 0000000..e1cf738
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/7zFormat.txt
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -1178,9 +675,90 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squash
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zBuf.c b/squashfs-tools/LZMA/lzma465/C/7zBuf.c
+new file mode 100644
+index 0000000..14e7f4e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zBuf.c
+@@ -0,0 +1,36 @@
++/* 7zBuf.c -- Byte Buffer
++2008-03-28
++Igor Pavlov
++Public domain */
++
++#include "7zBuf.h"
++
++void Buf_Init(CBuf *p)
++{
++  p->data = 0;
++  p->size = 0;
++}
++
++int Buf_Create(CBuf *p, size_t size, ISzAlloc *alloc)
++{
++  p->size = 0;
++  if (size == 0)
++  {
++    p->data = 0;
++    return 1;
++  }
++  p->data = (Byte *)alloc->Alloc(alloc, size);
++  if (p->data != 0)
++  {
++    p->size = size;
++    return 1;
++  }
++  return 0;
++}
++
++void Buf_Free(CBuf *p, ISzAlloc *alloc)
++{
++  alloc->Free(alloc, p->data);
++  p->data = 0;
++  p->size = 0;
++}
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zBuf.h b/squashfs-tools/LZMA/lzma465/C/7zBuf.h
+new file mode 100644
+index 0000000..c5bd718
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zBuf.h
+@@ -0,0 +1,31 @@
++/* 7zBuf.h -- Byte Buffer
++2008-10-04 : Igor Pavlov : Public domain */
++
++#ifndef __7Z_BUF_H
++#define __7Z_BUF_H
++
++#include "Types.h"
++
++typedef struct
++{
++  Byte *data;
++  size_t size;
++} CBuf;
++
++void Buf_Init(CBuf *p);
++int Buf_Create(CBuf *p, size_t size, ISzAlloc *alloc);
++void Buf_Free(CBuf *p, ISzAlloc *alloc);
++
++typedef struct
++{
++  Byte *data;
++  size_t size;
++  size_t pos;
++} CDynBuf;
++
++void DynBuf_Construct(CDynBuf *p);
++void DynBuf_SeekToBeg(CDynBuf *p);
++int DynBuf_Write(CDynBuf *p, const Byte *buf, size_t size, ISzAlloc *alloc);
++void DynBuf_Free(CDynBuf *p, ISzAlloc *alloc);
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zBuf2.c b/squashfs-tools/LZMA/lzma465/C/7zBuf2.c
+new file mode 100644
+index 0000000..8d17e0d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zBuf2.c
 @@ -0,0 +1,45 @@
 +/* 7zBuf2.c -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1227,84 +805,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs
 +  p->size = 0;
 +  p->pos = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,36 @@
-+/* 7zBuf.c -- Byte Buffer
-+2008-03-28
-+Igor Pavlov
-+Public domain */
-+
-+#include "7zBuf.h"
-+
-+void Buf_Init(CBuf *p)
-+{
-+  p->data = 0;
-+  p->size = 0;
-+}
-+
-+int Buf_Create(CBuf *p, size_t size, ISzAlloc *alloc)
-+{
-+  p->size = 0;
-+  if (size == 0)
-+  {
-+    p->data = 0;
-+    return 1;
-+  }
-+  p->data = (Byte *)alloc->Alloc(alloc, size);
-+  if (p->data != 0)
-+  {
-+    p->size = size;
-+    return 1;
-+  }
-+  return 0;
-+}
-+
-+void Buf_Free(CBuf *p, ISzAlloc *alloc)
-+{
-+  alloc->Free(alloc, p->data);
-+  p->data = 0;
-+  p->size = 0;
-+}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h
---- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,31 @@
-+/* 7zBuf.h -- Byte Buffer
-+2008-10-04 : Igor Pavlov : Public domain */
-+
-+#ifndef __7Z_BUF_H
-+#define __7Z_BUF_H
-+
-+#include "Types.h"
-+
-+typedef struct
-+{
-+  Byte *data;
-+  size_t size;
-+} CBuf;
-+
-+void Buf_Init(CBuf *p);
-+int Buf_Create(CBuf *p, size_t size, ISzAlloc *alloc);
-+void Buf_Free(CBuf *p, ISzAlloc *alloc);
-+
-+typedef struct
-+{
-+  Byte *data;
-+  size_t size;
-+  size_t pos;
-+} CDynBuf;
-+
-+void DynBuf_Construct(CDynBuf *p);
-+void DynBuf_SeekToBeg(CDynBuf *p);
-+int DynBuf_Write(CDynBuf *p, const Byte *buf, size_t size, ISzAlloc *alloc);
-+void DynBuf_Free(CDynBuf *p, ISzAlloc *alloc);
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c
---- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zCrc.c b/squashfs-tools/LZMA/lzma465/C/7zCrc.c
+new file mode 100644
+index 0000000..71962b2
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zCrc.c
 @@ -0,0 +1,35 @@
 +/* 7zCrc.c -- CRC32 calculation
 +2008-08-05
@@ -1341,9 +846,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-
 +{
 +  return CrcUpdate(CRC_INIT_VAL, data, size) ^ 0xFFFFFFFF;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h
---- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zCrc.h b/squashfs-tools/LZMA/lzma465/C/7zCrc.h
+new file mode 100644
+index 0000000..00dc29c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zCrc.h
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h -- CRC32 calculation
 +2008-03-13
@@ -1369,9 +876,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-
 +UInt32 MY_FAST_CALL CrcCalc(const void *data, size_t size);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs-tools-patched/LZMA/lzma465/C/7zFile.c
---- squashfs-tools/LZMA/lzma465/C/7zFile.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zFile.c b/squashfs-tools/LZMA/lzma465/C/7zFile.c
+new file mode 100644
+index 0000000..9a44c59
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zFile.c
 @@ -0,0 +1,263 @@
 +/* 7zFile.c -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1636,9 +1145,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs
 +{
 +  p->s.Write = FileOutStream_Write;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs-tools-patched/LZMA/lzma465/C/7zFile.h
---- squashfs-tools/LZMA/lzma465/C/7zFile.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zFile.h b/squashfs-tools/LZMA/lzma465/C/7zFile.h
+new file mode 100644
+index 0000000..fbef683
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zFile.h
 @@ -0,0 +1,74 @@
 +/* 7zFile.h -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1714,9 +1225,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs
 +void FileOutStream_CreateVTable(CFileOutStream *p);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squashfs-tools-patched/LZMA/lzma465/C/7zStream.c
---- squashfs-tools/LZMA/lzma465/C/7zStream.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zStream.c b/squashfs-tools/LZMA/lzma465/C/7zStream.c
+new file mode 100644
+index 0000000..86232aa
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zStream.c
 @@ -0,0 +1,169 @@
 +/* 7zStream.c -- 7z Stream functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -1887,9 +1400,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squash
 +{
 +  p->s.Read = SecToRead_Read;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h
---- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/7zVersion.h b/squashfs-tools/LZMA/lzma465/C/7zVersion.h
+new file mode 100644
+index 0000000..b7eb235
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/7zVersion.h
 @@ -0,0 +1,7 @@
 +#define MY_VER_MAJOR 4
 +#define MY_VER_MINOR 65
@@ -1898,9 +1413,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squas
 +#define MY_DATE "2009-02-03"
 +#define MY_COPYRIGHT ": Igor Pavlov : Public domain"
 +#define MY_VERSION_COPYRIGHT_DATE MY_VERSION " " MY_COPYRIGHT " : " MY_DATE
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-tools-patched/LZMA/lzma465/C/Alloc.c
---- squashfs-tools/LZMA/lzma465/C/Alloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Alloc.c b/squashfs-tools/LZMA/lzma465/C/Alloc.c
+new file mode 100644
+index 0000000..358a7b5
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Alloc.c
 @@ -0,0 +1,127 @@
 +/* Alloc.c -- Memory allocation functions
 +2008-09-24
@@ -2029,9 +1546,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-tools-patched/LZMA/lzma465/C/Alloc.h
---- squashfs-tools/LZMA/lzma465/C/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Alloc.h b/squashfs-tools/LZMA/lzma465/C/Alloc.h
+new file mode 100644
+index 0000000..ff0669c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Alloc.h
 @@ -0,0 +1,32 @@
 +/* Alloc.h -- Memory allocation functions
 +2008-03-13
@@ -2065,9 +1584,251 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp
+new file mode 100644
+index 0000000..9626b03
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp
+@@ -0,0 +1,199 @@
++# Microsoft Developer Studio Project File - Name="7z" - Package Owner=<4>
++# Microsoft Developer Studio Generated Build File, Format Version 6.00
++# ** DO NOT EDIT **
++
++# TARGTYPE "Win32 (x86) Console Application" 0x0103
++
++CFG=7z - Win32 Debug
++!MESSAGE This is not a valid makefile. To build this project using NMAKE,
++!MESSAGE use the Export Makefile command and run
++!MESSAGE 
++!MESSAGE NMAKE /f "7z.mak".
++!MESSAGE 
++!MESSAGE You can specify a configuration when running NMAKE
++!MESSAGE by defining the macro CFG on the command line. For example:
++!MESSAGE 
++!MESSAGE NMAKE /f "7z.mak" CFG="7z - Win32 Debug"
++!MESSAGE 
++!MESSAGE Possible choices for configuration are:
++!MESSAGE 
++!MESSAGE "7z - Win32 Release" (based on "Win32 (x86) Console Application")
++!MESSAGE "7z - Win32 Debug" (based on "Win32 (x86) Console Application")
++!MESSAGE 
++
++# Begin Project
++# PROP AllowPerConfigDependencies 0
++# PROP Scc_ProjName ""
++# PROP Scc_LocalPath ""
++CPP=cl.exe
++RSC=rc.exe
++
++!IF  "$(CFG)" == "7z - Win32 Release"
++
++# PROP BASE Use_MFC 0
++# PROP BASE Use_Debug_Libraries 0
++# PROP BASE Output_Dir "Release"
++# PROP BASE Intermediate_Dir "Release"
++# PROP BASE Target_Dir ""
++# PROP Use_MFC 0
++# PROP Use_Debug_Libraries 0
++# PROP Output_Dir "Release"
++# PROP Intermediate_Dir "Release"
++# PROP Ignore_Export_Lib 0
++# PROP Target_Dir ""
++# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
++# ADD CPP /nologo /MD /W3 /GX /O2 /D "NDEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /FAs /YX /FD /c
++# ADD BASE RSC /l 0x419 /d "NDEBUG"
++# ADD RSC /l 0x419 /d "NDEBUG"
++BSC32=bscmake.exe
++# ADD BASE BSC32 /nologo
++# ADD BSC32 /nologo
++LINK32=link.exe
++# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
++# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386 /out:"Release/7zDec.exe" /opt:NOWIN98
++# SUBTRACT LINK32 /pdb:none
++
++!ELSEIF  "$(CFG)" == "7z - Win32 Debug"
++
++# PROP BASE Use_MFC 0
++# PROP BASE Use_Debug_Libraries 1
++# PROP BASE Output_Dir "Debug"
++# PROP BASE Intermediate_Dir "Debug"
++# PROP BASE Target_Dir ""
++# PROP Use_MFC 0
++# PROP Use_Debug_Libraries 1
++# PROP Output_Dir "Debug"
++# PROP Intermediate_Dir "Debug"
++# PROP Ignore_Export_Lib 0
++# PROP Target_Dir ""
++# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
++# ADD CPP /nologo /W4 /Gm /GX /ZI /Od /D "_DEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "_SZ_ALLOC_DEBUG2" /D "_SZ_NO_INT_64_A" /YX /FD /GZ /c
++# ADD BASE RSC /l 0x419 /d "_DEBUG"
++# ADD RSC /l 0x419 /d "_DEBUG"
++BSC32=bscmake.exe
++# ADD BASE BSC32 /nologo
++# ADD BSC32 /nologo
++LINK32=link.exe
++# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
++# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /out:"Debug/7zDec.exe" /pdbtype:sept
++
++!ENDIF 
++
++# Begin Target
++
++# Name "7z - Win32 Release"
++# Name "7z - Win32 Debug"
++# Begin Group "Common"
++
++# PROP Default_Filter ""
++# Begin Source File
++
++SOURCE=..\..\7zBuf.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\7zBuf.h
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\7zCrc.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\7zCrc.h
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\7zFile.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\7zFile.h
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\7zStream.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\Bcj2.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\Bcj2.h
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\Bra.h
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\Bra86.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\LzmaDec.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\LzmaDec.h
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\Types.h
++# End Source File
++# End Group
++# Begin Source File
++
++SOURCE=.\7zAlloc.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zAlloc.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zDecode.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zDecode.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zExtract.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zExtract.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zHeader.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zHeader.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zIn.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zIn.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zItem.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zItem.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zMain.c
++# End Source File
++# End Target
++# End Project
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw
+new file mode 100644
+index 0000000..848d13c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw
+@@ -0,0 +1,29 @@
++Microsoft Developer Studio Workspace File, Format Version 6.00
++# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
++
++###############################################################################
++
++Project: "7z"=.\7z.dsp - Package Owner=<4>
++
++Package=<5>
++{{{
++}}}
++
++Package=<4>
++{{{
++}}}
++
++###############################################################################
++
++Global:
++
++Package=<5>
++{{{
++}}}
++
++Package=<3>
++{{{
++}}}
++
++###############################################################################
++
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c
+new file mode 100644
+index 0000000..4bfaf42
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c
 @@ -0,0 +1,77 @@
 +/* 7zAlloc.c -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2146,9 +1907,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +  #endif
 +  free(address);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h
+new file mode 100644
+index 0000000..e752ef1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h
 @@ -0,0 +1,15 @@
 +/* 7zAlloc.h -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2165,9 +1928,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +void SzFreeTemp(void *p, void *address);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c
+new file mode 100644
+index 0000000..02526f0
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c
 @@ -0,0 +1,254 @@
 +/* 7zDecode.c -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2423,9 +2188,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +    IAlloc_Free(allocMain, tempBuf[i]);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h
+new file mode 100644
+index 0000000..e19fe38
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h
 @@ -0,0 +1,13 @@
 +/* 7zDecode.h -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2440,245 +2207,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +    Byte *outBuffer, size_t outSize, ISzAlloc *allocMain);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,199 @@
-+# Microsoft Developer Studio Project File - Name="7z" - Package Owner=<4>
-+# Microsoft Developer Studio Generated Build File, Format Version 6.00
-+# ** DO NOT EDIT **
-+
-+# TARGTYPE "Win32 (x86) Console Application" 0x0103
-+
-+CFG=7z - Win32 Debug
-+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
-+!MESSAGE use the Export Makefile command and run
-+!MESSAGE 
-+!MESSAGE NMAKE /f "7z.mak".
-+!MESSAGE 
-+!MESSAGE You can specify a configuration when running NMAKE
-+!MESSAGE by defining the macro CFG on the command line. For example:
-+!MESSAGE 
-+!MESSAGE NMAKE /f "7z.mak" CFG="7z - Win32 Debug"
-+!MESSAGE 
-+!MESSAGE Possible choices for configuration are:
-+!MESSAGE 
-+!MESSAGE "7z - Win32 Release" (based on "Win32 (x86) Console Application")
-+!MESSAGE "7z - Win32 Debug" (based on "Win32 (x86) Console Application")
-+!MESSAGE 
-+
-+# Begin Project
-+# PROP AllowPerConfigDependencies 0
-+# PROP Scc_ProjName ""
-+# PROP Scc_LocalPath ""
-+CPP=cl.exe
-+RSC=rc.exe
-+
-+!IF  "$(CFG)" == "7z - Win32 Release"
-+
-+# PROP BASE Use_MFC 0
-+# PROP BASE Use_Debug_Libraries 0
-+# PROP BASE Output_Dir "Release"
-+# PROP BASE Intermediate_Dir "Release"
-+# PROP BASE Target_Dir ""
-+# PROP Use_MFC 0
-+# PROP Use_Debug_Libraries 0
-+# PROP Output_Dir "Release"
-+# PROP Intermediate_Dir "Release"
-+# PROP Ignore_Export_Lib 0
-+# PROP Target_Dir ""
-+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
-+# ADD CPP /nologo /MD /W3 /GX /O2 /D "NDEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /FAs /YX /FD /c
-+# ADD BASE RSC /l 0x419 /d "NDEBUG"
-+# ADD RSC /l 0x419 /d "NDEBUG"
-+BSC32=bscmake.exe
-+# ADD BASE BSC32 /nologo
-+# ADD BSC32 /nologo
-+LINK32=link.exe
-+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
-+# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386 /out:"Release/7zDec.exe" /opt:NOWIN98
-+# SUBTRACT LINK32 /pdb:none
-+
-+!ELSEIF  "$(CFG)" == "7z - Win32 Debug"
-+
-+# PROP BASE Use_MFC 0
-+# PROP BASE Use_Debug_Libraries 1
-+# PROP BASE Output_Dir "Debug"
-+# PROP BASE Intermediate_Dir "Debug"
-+# PROP BASE Target_Dir ""
-+# PROP Use_MFC 0
-+# PROP Use_Debug_Libraries 1
-+# PROP Output_Dir "Debug"
-+# PROP Intermediate_Dir "Debug"
-+# PROP Ignore_Export_Lib 0
-+# PROP Target_Dir ""
-+# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
-+# ADD CPP /nologo /W4 /Gm /GX /ZI /Od /D "_DEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "_SZ_ALLOC_DEBUG2" /D "_SZ_NO_INT_64_A" /YX /FD /GZ /c
-+# ADD BASE RSC /l 0x419 /d "_DEBUG"
-+# ADD RSC /l 0x419 /d "_DEBUG"
-+BSC32=bscmake.exe
-+# ADD BASE BSC32 /nologo
-+# ADD BSC32 /nologo
-+LINK32=link.exe
-+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
-+# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /out:"Debug/7zDec.exe" /pdbtype:sept
-+
-+!ENDIF 
-+
-+# Begin Target
-+
-+# Name "7z - Win32 Release"
-+# Name "7z - Win32 Debug"
-+# Begin Group "Common"
-+
-+# PROP Default_Filter ""
-+# Begin Source File
-+
-+SOURCE=..\..\7zBuf.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\7zBuf.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\7zCrc.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\7zCrc.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\7zFile.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\7zFile.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\7zStream.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\Bcj2.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\Bcj2.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\Bra.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\Bra86.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\LzmaDec.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\LzmaDec.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\Types.h
-+# End Source File
-+# End Group
-+# Begin Source File
-+
-+SOURCE=.\7zAlloc.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zAlloc.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zDecode.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zDecode.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zExtract.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zExtract.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zHeader.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zHeader.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zIn.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zIn.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zItem.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zItem.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zMain.c
-+# End Source File
-+# End Target
-+# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,29 @@
-+Microsoft Developer Studio Workspace File, Format Version 6.00
-+# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
-+
-+###############################################################################
-+
-+Project: "7z"=.\7z.dsp - Package Owner=<4>
-+
-+Package=<5>
-+{{{
-+}}}
-+
-+Package=<4>
-+{{{
-+}}}
-+
-+###############################################################################
-+
-+Global:
-+
-+Package=<5>
-+{{{
-+}}}
-+
-+Package=<3>
-+{{{
-+}}}
-+
-+###############################################################################
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c
+new file mode 100644
+index 0000000..ff79802
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c
 @@ -0,0 +1,93 @@
 +/* 7zExtract.c -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2773,9 +2306,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +  }
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h
+new file mode 100644
+index 0000000..5f78415
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h
 @@ -0,0 +1,41 @@
 +/* 7zExtract.h -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2818,9 +2353,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +    ISzAlloc *allocTemp);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c
+new file mode 100644
+index 0000000..e48faa4
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c
 @@ -0,0 +1,6 @@
 +/*  7zHeader.c -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2828,9 +2365,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +#include "7zHeader.h"
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h
+new file mode 100644
+index 0000000..9941b6f
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h
 @@ -0,0 +1,57 @@
 +/* 7zHeader.h -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2889,9 +2428,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c
+new file mode 100644
+index 0000000..f6143f8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c
 @@ -0,0 +1,1204 @@
 +/* 7zIn.c -- 7z Input functions
 +2008-12-31 : Igor Pavlov : Public domain */
@@ -4097,9 +3638,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c
 +    SzArEx_Free(p, allocMain);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h
+new file mode 100644
+index 0000000..c8430a7
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h
 @@ -0,0 +1,41 @@
 +/* 7zIn.h -- 7z Input functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4142,9 +3685,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h
 +SRes SzArEx_Open(CSzArEx *p, ILookInStream *inStream, ISzAlloc *allocMain, ISzAlloc *allocTemp);
 + 
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c
+new file mode 100644
+index 0000000..db44571
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c
 @@ -0,0 +1,127 @@
 +/* 7zItem.c -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4273,9 +3818,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +  IAlloc_Free(alloc, p->Files);
 +  SzAr_Init(p);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h
+new file mode 100644
+index 0000000..9f1366c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h
 @@ -0,0 +1,84 @@
 +/* 7zItem.h -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4361,9 +3908,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +void SzAr_Free(CSzAr *p, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c
+new file mode 100644
+index 0000000..0c20e8c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c
 @@ -0,0 +1,262 @@
 +/* 7zMain.c - Test application for 7z Decoder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4627,9 +4176,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain
 +    printf("\nERROR #%d\n", res);
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile b/squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile
+new file mode 100644
+index 0000000..c7bb05b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile
 @@ -0,0 +1,33 @@
 +MY_STATIC_LINK=1
 +
@@ -4664,9 +4215,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +	$(COMPL_O1)
 +$(C_OBJS): ../../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc b/squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc
+new file mode 100644
+index 0000000..2203dfc
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc
 @@ -0,0 +1,61 @@
 +PROG = 7zDec
 +CXX = g++
@@ -4729,9 +4282,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c
---- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Bcj2.c b/squashfs-tools/LZMA/lzma465/C/Bcj2.c
+new file mode 100644
+index 0000000..20199ce
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Bcj2.c
 @@ -0,0 +1,132 @@
 +/* Bcj2.c -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4865,9 +4420,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-t
 +  }
 +  return (outPos == outSize) ? SZ_OK : SZ_ERROR_DATA;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h
---- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Bcj2.h b/squashfs-tools/LZMA/lzma465/C/Bcj2.h
+new file mode 100644
+index 0000000..32d450b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Bcj2.h
 @@ -0,0 +1,30 @@
 +/* Bcj2.h -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4899,98 +4456,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-t
 +    Byte *outBuf, SizeT outSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-tools-patched/LZMA/lzma465/C/Bra86.c
---- squashfs-tools/LZMA/lzma465/C/Bra86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,85 @@
-+/* Bra86.c -- Converter for x86 code (BCJ)
-+2008-10-04 : Igor Pavlov : Public domain */
-+
-+#include "Bra.h"
-+
-+#define Test86MSByte(b) ((b) == 0 || (b) == 0xFF)
-+
-+const Byte kMaskToAllowedStatus[8] = {1, 1, 1, 0, 1, 0, 0, 0};
-+const Byte kMaskToBitNumber[8] = {0, 1, 2, 2, 3, 3, 3, 3};
-+
-+SizeT x86_Convert(Byte *data, SizeT size, UInt32 ip, UInt32 *state, int encoding)
-+{
-+  SizeT bufferPos = 0, prevPosT;
-+  UInt32 prevMask = *state & 0x7;
-+  if (size < 5)
-+    return 0;
-+  ip += 5;
-+  prevPosT = (SizeT)0 - 1;
-+
-+  for (;;)
-+  {
-+    Byte *p = data + bufferPos;
-+    Byte *limit = data + size - 4;
-+    for (; p < limit; p++)
-+      if ((*p & 0xFE) == 0xE8)
-+        break;
-+    bufferPos = (SizeT)(p - data);
-+    if (p >= limit)
-+      break;
-+    prevPosT = bufferPos - prevPosT;
-+    if (prevPosT > 3)
-+      prevMask = 0;
-+    else
-+    {
-+      prevMask = (prevMask << ((int)prevPosT - 1)) & 0x7;
-+      if (prevMask != 0)
-+      {
-+        Byte b = p[4 - kMaskToBitNumber[prevMask]];
-+        if (!kMaskToAllowedStatus[prevMask] || Test86MSByte(b))
-+        {
-+          prevPosT = bufferPos;
-+          prevMask = ((prevMask << 1) & 0x7) | 1;
-+          bufferPos++;
-+          continue;
-+        }
-+      }
-+    }
-+    prevPosT = bufferPos;
-+
-+    if (Test86MSByte(p[4]))
-+    {
-+      UInt32 src = ((UInt32)p[4] << 24) | ((UInt32)p[3] << 16) | ((UInt32)p[2] << 8) | ((UInt32)p[1]);
-+      UInt32 dest;
-+      for (;;)
-+      {
-+        Byte b;
-+        int index;
-+        if (encoding)
-+          dest = (ip + (UInt32)bufferPos) + src;
-+        else
-+          dest = src - (ip + (UInt32)bufferPos);
-+        if (prevMask == 0)
-+          break;
-+        index = kMaskToBitNumber[prevMask] * 8;
-+        b = (Byte)(dest >> (24 - index));
-+        if (!Test86MSByte(b))
-+          break;
-+        src = dest ^ ((1 << (32 - index)) - 1);
-+      }
-+      p[4] = (Byte)(~(((dest >> 24) & 1) - 1));
-+      p[3] = (Byte)(dest >> 16);
-+      p[2] = (Byte)(dest >> 8);
-+      p[1] = (Byte)dest;
-+      bufferPos += 5;
-+    }
-+    else
-+    {
-+      prevMask = ((prevMask << 1) & 0x7) | 1;
-+      bufferPos++;
-+    }
-+  }
-+  prevPosT = bufferPos - prevPosT;
-+  *state = ((prevPosT > 3) ? 0 : ((prevMask << ((int)prevPosT - 1)) & 0x7));
-+  return bufferPos;
-+}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-tools-patched/LZMA/lzma465/C/Bra.c
---- squashfs-tools/LZMA/lzma465/C/Bra.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Bra.c b/squashfs-tools/LZMA/lzma465/C/Bra.c
+new file mode 100644
+index 0000000..5e54695
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Bra.c
 @@ -0,0 +1,133 @@
 +/* Bra.c -- Converters for RISC code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5125,9 +4595,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-to
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-tools-patched/LZMA/lzma465/C/Bra.h
---- squashfs-tools/LZMA/lzma465/C/Bra.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Bra.h b/squashfs-tools/LZMA/lzma465/C/Bra.h
+new file mode 100644
+index 0000000..45e231e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Bra.h
 @@ -0,0 +1,60 @@
 +/* Bra.h -- Branch converters for executables
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5189,9 +4661,102 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-to
 +SizeT IA64_Convert(Byte *data, SizeT size, UInt32 ip, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c
---- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Bra86.c b/squashfs-tools/LZMA/lzma465/C/Bra86.c
+new file mode 100644
+index 0000000..1ee0e70
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Bra86.c
+@@ -0,0 +1,85 @@
++/* Bra86.c -- Converter for x86 code (BCJ)
++2008-10-04 : Igor Pavlov : Public domain */
++
++#include "Bra.h"
++
++#define Test86MSByte(b) ((b) == 0 || (b) == 0xFF)
++
++const Byte kMaskToAllowedStatus[8] = {1, 1, 1, 0, 1, 0, 0, 0};
++const Byte kMaskToBitNumber[8] = {0, 1, 2, 2, 3, 3, 3, 3};
++
++SizeT x86_Convert(Byte *data, SizeT size, UInt32 ip, UInt32 *state, int encoding)
++{
++  SizeT bufferPos = 0, prevPosT;
++  UInt32 prevMask = *state & 0x7;
++  if (size < 5)
++    return 0;
++  ip += 5;
++  prevPosT = (SizeT)0 - 1;
++
++  for (;;)
++  {
++    Byte *p = data + bufferPos;
++    Byte *limit = data + size - 4;
++    for (; p < limit; p++)
++      if ((*p & 0xFE) == 0xE8)
++        break;
++    bufferPos = (SizeT)(p - data);
++    if (p >= limit)
++      break;
++    prevPosT = bufferPos - prevPosT;
++    if (prevPosT > 3)
++      prevMask = 0;
++    else
++    {
++      prevMask = (prevMask << ((int)prevPosT - 1)) & 0x7;
++      if (prevMask != 0)
++      {
++        Byte b = p[4 - kMaskToBitNumber[prevMask]];
++        if (!kMaskToAllowedStatus[prevMask] || Test86MSByte(b))
++        {
++          prevPosT = bufferPos;
++          prevMask = ((prevMask << 1) & 0x7) | 1;
++          bufferPos++;
++          continue;
++        }
++      }
++    }
++    prevPosT = bufferPos;
++
++    if (Test86MSByte(p[4]))
++    {
++      UInt32 src = ((UInt32)p[4] << 24) | ((UInt32)p[3] << 16) | ((UInt32)p[2] << 8) | ((UInt32)p[1]);
++      UInt32 dest;
++      for (;;)
++      {
++        Byte b;
++        int index;
++        if (encoding)
++          dest = (ip + (UInt32)bufferPos) + src;
++        else
++          dest = src - (ip + (UInt32)bufferPos);
++        if (prevMask == 0)
++          break;
++        index = kMaskToBitNumber[prevMask] * 8;
++        b = (Byte)(dest >> (24 - index));
++        if (!Test86MSByte(b))
++          break;
++        src = dest ^ ((1 << (32 - index)) - 1);
++      }
++      p[4] = (Byte)(~(((dest >> 24) & 1) - 1));
++      p[3] = (Byte)(dest >> 16);
++      p[2] = (Byte)(dest >> 8);
++      p[1] = (Byte)dest;
++      bufferPos += 5;
++    }
++    else
++    {
++      prevMask = ((prevMask << 1) & 0x7) | 1;
++      bufferPos++;
++    }
++  }
++  prevPosT = bufferPos - prevPosT;
++  *state = ((prevPosT > 3) ? 0 : ((prevMask << ((int)prevPosT - 1)) & 0x7));
++  return bufferPos;
++}
+diff --git a/squashfs-tools/LZMA/lzma465/C/BraIA64.c b/squashfs-tools/LZMA/lzma465/C/BraIA64.c
+new file mode 100644
+index 0000000..0b4ee85
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/BraIA64.c
 @@ -0,0 +1,67 @@
 +/* BraIA64.c -- Converter for IA-64 code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5260,9 +4825,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashf
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h
---- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/CpuArch.h b/squashfs-tools/LZMA/lzma465/C/CpuArch.h
+new file mode 100644
+index 0000000..7384b0c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/CpuArch.h
 @@ -0,0 +1,69 @@
 +/* CpuArch.h
 +2008-08-05
@@ -5333,9 +4900,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashf
 +#define GetBe16(p) (((UInt16)((const Byte *)(p))[0] << 8) | ((const Byte *)(p))[1])
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs-tools-patched/LZMA/lzma465/C/LzFind.c
---- squashfs-tools/LZMA/lzma465/C/LzFind.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzFind.c b/squashfs-tools/LZMA/lzma465/C/LzFind.c
+new file mode 100644
+index 0000000..34f4f09
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzFind.c
 @@ -0,0 +1,751 @@
 +/* LzFind.c -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6088,9 +5657,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs
 +    vTable->Skip = (Mf_Skip_Func)Bt4_MatchFinder_Skip;
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs-tools-patched/LZMA/lzma465/C/LzFind.h
---- squashfs-tools/LZMA/lzma465/C/LzFind.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzFind.h b/squashfs-tools/LZMA/lzma465/C/LzFind.h
+new file mode 100644
+index 0000000..5b9cebf
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzFind.h
 @@ -0,0 +1,107 @@
 +/* LzFind.h -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6199,9 +5770,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs
 +void Hc3Zip_MatchFinder_Skip(CMatchFinder *p, UInt32 num);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzFindMt.c b/squashfs-tools/LZMA/lzma465/C/LzFindMt.c
+new file mode 100644
+index 0000000..b49cd76
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzFindMt.c
 @@ -0,0 +1,793 @@
 +/* LzFindMt.c -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6996,9 +6569,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squash
 +    */
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzFindMt.h b/squashfs-tools/LZMA/lzma465/C/LzFindMt.h
+new file mode 100644
+index 0000000..2c7e462
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzFindMt.h
 @@ -0,0 +1,97 @@
 +/* LzFindMt.h -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7097,9 +6672,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squash
 +void MatchFinderMt_ReleaseStream(CMatchFinderMt *p);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs-tools-patched/LZMA/lzma465/C/LzHash.h
---- squashfs-tools/LZMA/lzma465/C/LzHash.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzHash.h b/squashfs-tools/LZMA/lzma465/C/LzHash.h
+new file mode 100644
+index 0000000..9f4173e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzHash.h
 @@ -0,0 +1,54 @@
 +/* LzHash.h -- HASH functions for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7155,9 +6732,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs
 +  hash4Value = (temp ^ ((UInt32)cur[2] << 8) ^ (p->crc[cur[3]] << 5)) & (kHash4Size - 1); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaDec.c b/squashfs-tools/LZMA/lzma465/C/LzmaDec.c
+new file mode 100644
+index 0000000..d87eb19
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaDec.c
 @@ -0,0 +1,1007 @@
 +/* LzmaDec.c -- LZMA Decoder
 +2008-11-06 : Igor Pavlov : Public domain */
@@ -8166,9 +7745,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashf
 +  LzmaDec_FreeProbs(&p, alloc);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaDec.h b/squashfs-tools/LZMA/lzma465/C/LzmaDec.h
+new file mode 100644
+index 0000000..98cdbe9
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaDec.h
 @@ -0,0 +1,223 @@
 +/* LzmaDec.h -- LZMA Decoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -8393,9 +7974,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashf
 +    ELzmaStatus *status, ISzAlloc *alloc);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaEnc.c b/squashfs-tools/LZMA/lzma465/C/LzmaEnc.c
+new file mode 100644
+index 0000000..3a2c9da
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaEnc.c
 @@ -0,0 +1,2281 @@
 +/* LzmaEnc.c -- LZMA Encoder
 +2009-02-02 : Igor Pavlov : Public domain */
@@ -10678,9 +10261,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashf
 +  LzmaEnc_Destroy(p, alloc, allocBig);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaEnc.h b/squashfs-tools/LZMA/lzma465/C/LzmaEnc.h
+new file mode 100644
+index 0000000..bfbc7d2
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaEnc.h
 @@ -0,0 +1,72 @@
 +/*  LzmaEnc.h -- LZMA Encoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10754,17 +10339,214 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashf
 +    ICompressProgress *progress, ISzAlloc *alloc, ISzAlloc *allocBig);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib.c b/squashfs-tools/LZMA/lzma465/C/LzmaLib.c
+new file mode 100644
+index 0000000..02a5118
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib.c
+@@ -0,0 +1,46 @@
++/* LzmaLib.c -- LZMA library wrapper
++2008-08-05
++Igor Pavlov
++Public domain */
++
++#include "LzmaEnc.h"
++#include "LzmaDec.h"
++#include "Alloc.h"
++#include "LzmaLib.h"
++
++static void *SzAlloc(void *p, size_t size) { p = p; return MyAlloc(size); }
++static void SzFree(void *p, void *address) { p = p; MyFree(address); }
++static ISzAlloc g_Alloc = { SzAlloc, SzFree };
++
++MY_STDAPI LzmaCompress(unsigned char *dest, size_t  *destLen, const unsigned char *src, size_t  srcLen,
++  unsigned char *outProps, size_t *outPropsSize,
++  int level, /* 0 <= level <= 9, default = 5 */
++  unsigned dictSize, /* use (1 << N) or (3 << N). 4 KB < dictSize <= 128 MB */
++  int lc, /* 0 <= lc <= 8, default = 3  */
++  int lp, /* 0 <= lp <= 4, default = 0  */
++  int pb, /* 0 <= pb <= 4, default = 2  */
++  int fb,  /* 5 <= fb <= 273, default = 32 */
++  int numThreads /* 1 or 2, default = 2 */
++)
++{
++  CLzmaEncProps props;
++  LzmaEncProps_Init(&props);
++  props.level = level;
++  props.dictSize = dictSize;
++  props.lc = lc;
++  props.lp = lp;
++  props.pb = pb;
++  props.fb = fb;
++  props.numThreads = numThreads;
++
++  return LzmaEncode(dest, destLen, src, srcLen, &props, outProps, outPropsSize, 0,
++      NULL, &g_Alloc, &g_Alloc);
++}
++
++
++MY_STDAPI LzmaUncompress(unsigned char *dest, size_t  *destLen, const unsigned char *src, size_t  *srcLen,
++  const unsigned char *props, size_t propsSize)
++{
++  ELzmaStatus status;
++  return LzmaDecode(dest, destLen, src, srcLen, props, (unsigned)propsSize, LZMA_FINISH_ANY, &status, &g_Alloc);
++}
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib.h b/squashfs-tools/LZMA/lzma465/C/LzmaLib.h
+new file mode 100644
+index 0000000..5c9eeec
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib.h
+@@ -0,0 +1,135 @@
++/* LzmaLib.h -- LZMA library interface
++2008-08-05
++Igor Pavlov
++Public domain */
++
++#ifndef __LZMALIB_H
++#define __LZMALIB_H
++
++#include "Types.h"
++
++#ifdef __cplusplus
++  #define MY_EXTERN_C extern "C"
++#else
++  #define MY_EXTERN_C extern
++#endif
++
++#define MY_STDAPI MY_EXTERN_C int MY_STD_CALL
++
++#define LZMA_PROPS_SIZE 5
++
++/*
++RAM requirements for LZMA:
++  for compression:   (dictSize * 11.5 + 6 MB) + state_size
++  for decompression: dictSize + state_size
++    state_size = (4 + (1.5 << (lc + lp))) KB
++    by default (lc=3, lp=0), state_size = 16 KB.
++
++LZMA properties (5 bytes) format
++    Offset Size  Description
++      0     1    lc, lp and pb in encoded form.
++      1     4    dictSize (little endian).
++*/
++
++/*
++LzmaCompress
++------------
++
++outPropsSize -
++     In:  the pointer to the size of outProps buffer; *outPropsSize = LZMA_PROPS_SIZE = 5.
++     Out: the pointer to the size of written properties in outProps buffer; *outPropsSize = LZMA_PROPS_SIZE = 5.
++
++  LZMA Encoder will use defult values for any parameter, if it is
++  -1  for any from: level, loc, lp, pb, fb, numThreads
++   0  for dictSize
++  
++level - compression level: 0 <= level <= 9;
++
++  level dictSize algo  fb
++    0:    16 KB   0    32
++    1:    64 KB   0    32
++    2:   256 KB   0    32
++    3:     1 MB   0    32
++    4:     4 MB   0    32
++    5:    16 MB   1    32
++    6:    32 MB   1    32
++    7+:   64 MB   1    64
++ 
++  The default value for "level" is 5.
++
++  algo = 0 means fast method
++  algo = 1 means normal method
++
++dictSize - The dictionary size in bytes. The maximum value is
++        128 MB = (1 << 27) bytes for 32-bit version
++          1 GB = (1 << 30) bytes for 64-bit version
++     The default value is 16 MB = (1 << 24) bytes.
++     It's recommended to use the dictionary that is larger than 4 KB and
++     that can be calculated as (1 << N) or (3 << N) sizes.
++
++lc - The number of literal context bits (high bits of previous literal).
++     It can be in the range from 0 to 8. The default value is 3.
++     Sometimes lc=4 gives the gain for big files.
++
++lp - The number of literal pos bits (low bits of current position for literals).
++     It can be in the range from 0 to 4. The default value is 0.
++     The lp switch is intended for periodical data when the period is equal to 2^lp.
++     For example, for 32-bit (4 bytes) periodical data you can use lp=2. Often it's
++     better to set lc=0, if you change lp switch.
++
++pb - The number of pos bits (low bits of current position).
++     It can be in the range from 0 to 4. The default value is 2.
++     The pb switch is intended for periodical data when the period is equal 2^pb.
++
++fb - Word size (the number of fast bytes).
++     It can be in the range from 5 to 273. The default value is 32.
++     Usually, a big number gives a little bit better compression ratio and
++     slower compression process.
++
++numThreads - The number of thereads. 1 or 2. The default value is 2.
++     Fast mode (algo = 0) can use only 1 thread.
++
++Out:
++  destLen  - processed output size
++Returns:
++  SZ_OK               - OK
++  SZ_ERROR_MEM        - Memory allocation error
++  SZ_ERROR_PARAM      - Incorrect paramater
++  SZ_ERROR_OUTPUT_EOF - output buffer overflow
++  SZ_ERROR_THREAD     - errors in multithreading functions (only for Mt version)
++*/
++
++MY_STDAPI LzmaCompress(unsigned char *dest, size_t *destLen, const unsigned char *src, size_t srcLen,
++  unsigned char *outProps, size_t *outPropsSize, /* *outPropsSize must be = 5 */
++  int level,      /* 0 <= level <= 9, default = 5 */
++  unsigned dictSize,  /* default = (1 << 24) */
++  int lc,        /* 0 <= lc <= 8, default = 3  */
++  int lp,        /* 0 <= lp <= 4, default = 0  */
++  int pb,        /* 0 <= pb <= 4, default = 2  */
++  int fb,        /* 5 <= fb <= 273, default = 32 */
++  int numThreads /* 1 or 2, default = 2 */
++  );
++
++/*
++LzmaUncompress
++--------------
++In:
++  dest     - output data
++  destLen  - output data size
++  src      - input data
++  srcLen   - input data size
++Out:
++  destLen  - processed output size
++  srcLen   - processed input size
++Returns:
++  SZ_OK                - OK
++  SZ_ERROR_DATA        - Data error
++  SZ_ERROR_MEM         - Memory allocation arror
++  SZ_ERROR_UNSUPPORTED - Unsupported properties
++  SZ_ERROR_INPUT_EOF   - it needs more bytes in input buffer (src)
++*/
++
++MY_STDAPI LzmaUncompress(unsigned char *dest, size_t *destLen, const unsigned char *src, SizeT *srcLen,
++  const unsigned char *props, size_t propsSize);
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def
+new file mode 100644
+index 0000000..8bc6add
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def
 @@ -0,0 +1,4 @@
 +EXPORTS
 +  LzmaCompress
 +  LzmaUncompress
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
+new file mode 100644
+index 0000000..3ba6d25
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="LzmaLib" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -10944,9 +10726,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
+new file mode 100644
+index 0000000..6faf333
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -10977,9 +10761,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
+new file mode 100644
+index 0000000..845545d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
 @@ -0,0 +1,12 @@
 +/* LzmaLibExports.c -- LZMA library DLL Entry point
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10993,9 +10779,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibEx
 +  lpReserved = lpReserved;
 +  return TRUE;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile b/squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile
+new file mode 100644
+index 0000000..1e6b40c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile
 @@ -0,0 +1,37 @@
 +MY_STATIC_LINK=1
 +SLIB = sLZMA.lib
@@ -11034,206 +10822,21 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile 
 +	$(COMPL_O2)
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc b/squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc
+new file mode 100644
+index 0000000..1e48916
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc
 @@ -0,0 +1,4 @@
 +#include "../../CPP/7zip/MyVersionInfo.rc"
 +
 +MY_VERSION_INFO_DLL("LZMA library", "LZMA")
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,46 @@
-+/* LzmaLib.c -- LZMA library wrapper
-+2008-08-05
-+Igor Pavlov
-+Public domain */
-+
-+#include "LzmaEnc.h"
-+#include "LzmaDec.h"
-+#include "Alloc.h"
-+#include "LzmaLib.h"
-+
-+static void *SzAlloc(void *p, size_t size) { p = p; return MyAlloc(size); }
-+static void SzFree(void *p, void *address) { p = p; MyFree(address); }
-+static ISzAlloc g_Alloc = { SzAlloc, SzFree };
-+
-+MY_STDAPI LzmaCompress(unsigned char *dest, size_t  *destLen, const unsigned char *src, size_t  srcLen,
-+  unsigned char *outProps, size_t *outPropsSize,
-+  int level, /* 0 <= level <= 9, default = 5 */
-+  unsigned dictSize, /* use (1 << N) or (3 << N). 4 KB < dictSize <= 128 MB */
-+  int lc, /* 0 <= lc <= 8, default = 3  */
-+  int lp, /* 0 <= lp <= 4, default = 0  */
-+  int pb, /* 0 <= pb <= 4, default = 2  */
-+  int fb,  /* 5 <= fb <= 273, default = 32 */
-+  int numThreads /* 1 or 2, default = 2 */
-+)
-+{
-+  CLzmaEncProps props;
-+  LzmaEncProps_Init(&props);
-+  props.level = level;
-+  props.dictSize = dictSize;
-+  props.lc = lc;
-+  props.lp = lp;
-+  props.pb = pb;
-+  props.fb = fb;
-+  props.numThreads = numThreads;
-+
-+  return LzmaEncode(dest, destLen, src, srcLen, &props, outProps, outPropsSize, 0,
-+      NULL, &g_Alloc, &g_Alloc);
-+}
-+
-+
-+MY_STDAPI LzmaUncompress(unsigned char *dest, size_t  *destLen, const unsigned char *src, size_t  *srcLen,
-+  const unsigned char *props, size_t propsSize)
-+{
-+  ELzmaStatus status;
-+  return LzmaDecode(dest, destLen, src, srcLen, props, (unsigned)propsSize, LZMA_FINISH_ANY, &status, &g_Alloc);
-+}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,135 @@
-+/* LzmaLib.h -- LZMA library interface
-+2008-08-05
-+Igor Pavlov
-+Public domain */
-+
-+#ifndef __LZMALIB_H
-+#define __LZMALIB_H
-+
-+#include "Types.h"
-+
-+#ifdef __cplusplus
-+  #define MY_EXTERN_C extern "C"
-+#else
-+  #define MY_EXTERN_C extern
-+#endif
-+
-+#define MY_STDAPI MY_EXTERN_C int MY_STD_CALL
-+
-+#define LZMA_PROPS_SIZE 5
-+
-+/*
-+RAM requirements for LZMA:
-+  for compression:   (dictSize * 11.5 + 6 MB) + state_size
-+  for decompression: dictSize + state_size
-+    state_size = (4 + (1.5 << (lc + lp))) KB
-+    by default (lc=3, lp=0), state_size = 16 KB.
-+
-+LZMA properties (5 bytes) format
-+    Offset Size  Description
-+      0     1    lc, lp and pb in encoded form.
-+      1     4    dictSize (little endian).
-+*/
-+
-+/*
-+LzmaCompress
-+------------
-+
-+outPropsSize -
-+     In:  the pointer to the size of outProps buffer; *outPropsSize = LZMA_PROPS_SIZE = 5.
-+     Out: the pointer to the size of written properties in outProps buffer; *outPropsSize = LZMA_PROPS_SIZE = 5.
-+
-+  LZMA Encoder will use defult values for any parameter, if it is
-+  -1  for any from: level, loc, lp, pb, fb, numThreads
-+   0  for dictSize
-+  
-+level - compression level: 0 <= level <= 9;
-+
-+  level dictSize algo  fb
-+    0:    16 KB   0    32
-+    1:    64 KB   0    32
-+    2:   256 KB   0    32
-+    3:     1 MB   0    32
-+    4:     4 MB   0    32
-+    5:    16 MB   1    32
-+    6:    32 MB   1    32
-+    7+:   64 MB   1    64
-+ 
-+  The default value for "level" is 5.
-+
-+  algo = 0 means fast method
-+  algo = 1 means normal method
-+
-+dictSize - The dictionary size in bytes. The maximum value is
-+        128 MB = (1 << 27) bytes for 32-bit version
-+          1 GB = (1 << 30) bytes for 64-bit version
-+     The default value is 16 MB = (1 << 24) bytes.
-+     It's recommended to use the dictionary that is larger than 4 KB and
-+     that can be calculated as (1 << N) or (3 << N) sizes.
-+
-+lc - The number of literal context bits (high bits of previous literal).
-+     It can be in the range from 0 to 8. The default value is 3.
-+     Sometimes lc=4 gives the gain for big files.
-+
-+lp - The number of literal pos bits (low bits of current position for literals).
-+     It can be in the range from 0 to 4. The default value is 0.
-+     The lp switch is intended for periodical data when the period is equal to 2^lp.
-+     For example, for 32-bit (4 bytes) periodical data you can use lp=2. Often it's
-+     better to set lc=0, if you change lp switch.
-+
-+pb - The number of pos bits (low bits of current position).
-+     It can be in the range from 0 to 4. The default value is 2.
-+     The pb switch is intended for periodical data when the period is equal 2^pb.
-+
-+fb - Word size (the number of fast bytes).
-+     It can be in the range from 5 to 273. The default value is 32.
-+     Usually, a big number gives a little bit better compression ratio and
-+     slower compression process.
-+
-+numThreads - The number of thereads. 1 or 2. The default value is 2.
-+     Fast mode (algo = 0) can use only 1 thread.
-+
-+Out:
-+  destLen  - processed output size
-+Returns:
-+  SZ_OK               - OK
-+  SZ_ERROR_MEM        - Memory allocation error
-+  SZ_ERROR_PARAM      - Incorrect paramater
-+  SZ_ERROR_OUTPUT_EOF - output buffer overflow
-+  SZ_ERROR_THREAD     - errors in multithreading functions (only for Mt version)
-+*/
-+
-+MY_STDAPI LzmaCompress(unsigned char *dest, size_t *destLen, const unsigned char *src, size_t srcLen,
-+  unsigned char *outProps, size_t *outPropsSize, /* *outPropsSize must be = 5 */
-+  int level,      /* 0 <= level <= 9, default = 5 */
-+  unsigned dictSize,  /* default = (1 << 24) */
-+  int lc,        /* 0 <= lc <= 8, default = 3  */
-+  int lp,        /* 0 <= lp <= 4, default = 0  */
-+  int pb,        /* 0 <= pb <= 4, default = 2  */
-+  int fb,        /* 5 <= fb <= 273, default = 32 */
-+  int numThreads /* 1 or 2, default = 2 */
-+  );
-+
-+/*
-+LzmaUncompress
-+--------------
-+In:
-+  dest     - output data
-+  destLen  - output data size
-+  src      - input data
-+  srcLen   - input data size
-+Out:
-+  destLen  - processed output size
-+  srcLen   - processed input size
-+Returns:
-+  SZ_OK                - OK
-+  SZ_ERROR_DATA        - Data error
-+  SZ_ERROR_MEM         - Memory allocation arror
-+  SZ_ERROR_UNSUPPORTED - Unsupported properties
-+  SZ_ERROR_INPUT_EOF   - it needs more bytes in input buffer (src)
-+*/
-+
-+MY_STDAPI LzmaUncompress(unsigned char *dest, size_t *destLen, const unsigned char *src, SizeT *srcLen,
-+  const unsigned char *props, size_t propsSize);
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
+new file mode 100644
+index 0000000..b801dd1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
 @@ -0,0 +1,61 @@
 +/* Lzma86Dec.c -- LZMA + x86 (BCJ) Filter Decoder
 +2008-04-07
@@ -11296,9 +10899,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +  }
 +  return SZ_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
+new file mode 100644
+index 0000000..f711821
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
 @@ -0,0 +1,45 @@
 +/* Lzma86Dec.h -- LZMA + x86 (BCJ) Filter Decoder
 +2008-08-05
@@ -11345,9 +10950,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +SRes Lzma86_Decode(Byte *dest, SizeT *destLen, const Byte *src, SizeT *srcLen);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
+new file mode 100644
+index 0000000..efc81ea
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
 @@ -0,0 +1,113 @@
 +/* Lzma86Enc.c -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11462,9 +11069,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +    MyFree(filteredStream);
 +  return mainResult;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
+new file mode 100644
+index 0000000..10be1cd
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
 @@ -0,0 +1,72 @@
 +/* Lzma86Enc.h -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11538,9 +11147,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +    int level, UInt32 dictSize, int filterMode);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
+new file mode 100644
+index 0000000..016d7b0
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
 @@ -0,0 +1,254 @@
 +/* LzmaUtil.c -- Test application for LZMA compression
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -11796,9 +11407,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
+new file mode 100644
+index 0000000..faac2e6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
 @@ -0,0 +1,168 @@
 +# Microsoft Developer Studio Project File - Name="LzmaUtil" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -11968,9 +11581,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
+new file mode 100644
+index 0000000..c52eaf6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -12001,9 +11616,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
+new file mode 100644
+index 0000000..fbb98b8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 @@ -0,0 +1,29 @@
 +MY_STATIC_LINK=1
 +PROG = LZMAc.exe
@@ -12034,9 +11651,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +	$(COMPL_O2)
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc
+new file mode 100644
+index 0000000..9fcdead
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc
 @@ -0,0 +1,44 @@
 +PROG = lzma
 +CXX = g++
@@ -12082,9 +11701,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashfs-tools-patched/LZMA/lzma465/C/Threads.c
---- squashfs-tools/LZMA/lzma465/C/Threads.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Threads.c b/squashfs-tools/LZMA/lzma465/C/Threads.c
+new file mode 100644
+index 0000000..4fdd69b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Threads.c
 @@ -0,0 +1,109 @@
 +/* Threads.c -- multithreading library
 +2008-08-05
@@ -12195,9 +11816,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashf
 +  return 0;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashfs-tools-patched/LZMA/lzma465/C/Threads.h
---- squashfs-tools/LZMA/lzma465/C/Threads.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Threads.h b/squashfs-tools/LZMA/lzma465/C/Threads.h
+new file mode 100644
+index 0000000..a823e57
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Threads.h
 @@ -0,0 +1,68 @@
 +/* Threads.h -- multithreading library
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -12267,9 +11890,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashf
 +
 +#endif
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-tools-patched/LZMA/lzma465/C/Types.h
---- squashfs-tools/LZMA/lzma465/C/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/C/Types.h b/squashfs-tools/LZMA/lzma465/C/Types.h
+new file mode 100644
+index 0000000..1af5cfc
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/C/Types.h
 @@ -0,0 +1,208 @@
 +/* Types.h -- Basic types
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -12479,9 +12104,154 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-
 +#define IAlloc_Free(p, a) (p)->Free((p), a)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashfs-tools-patched/LZMA/lzma465/history.txt
---- squashfs-tools/LZMA/lzma465/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/history.txt	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/Methods.txt b/squashfs-tools/LZMA/lzma465/Methods.txt
+new file mode 100644
+index 0000000..5b5cb93
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/Methods.txt
+@@ -0,0 +1,137 @@
++7-Zip method IDs (4.65)
++-----------------------
++
++Each compression or crypto method in 7z has unique binary value (ID).
++The length of ID in bytes is arbitrary but it can not exceed 63 bits (8 bytes).
++
++If you want to add some new ID, you have two ways:
++1) Write request for allocating IDs to 7-zip developers.
++2) Generate 8-bytes ID:
++
++    3F ZZ ZZ ZZ ZZ ZZ MM MM 
++
++    3F              - Prefix for random IDs (1 byte)
++    ZZ ZZ ZZ ZZ ZZ  - Developer ID (5 bytes). Use real random bytes. 
++                      
++    MM MM           - Method ID (2 bytes)
++
++    You can notify 7-Zip developers about your Developer ID / Method ID.
++
++    Note: Use new ID only if old codec can not decode data encoded with new version.
++
++
++List of defined IDs
++-------------------
++      
++00 - Copy
++
++02 - Common
++   03 Swap
++      - 2 Swap2
++      - 4 Swap4
++
++03 - 7z
++   01 - LZMA
++      01 - Version
++  
++   03 - Branch
++      01 - x86
++         03  - BCJ
++         1B  - BCJ2
++      02 - PPC
++         05 - PPC (Big Endian)
++      03 - Alpha
++         01 - Alpha
++      04 - IA64
++         01 - IA64
++      05 - ARM
++         01 - ARM
++      06 - M68
++         05 - M68 (Big Endian)
++      07 - ARM Thumb
++         01 - ARMT
++      08 - SPARC
++         05 - SPARC
++
++   04 - PPMD
++      01 - Version
++
++   7F -
++      01 - experimental methods.
++
++
++04 - Misc
++   00 - Reserved
++   01 - Zip
++      00 - Copy (not used). Use {00} instead
++      01 - Shrink
++      06 - Implode
++      08 - Deflate
++      09 - Deflate64
++      12 - BZip2 (not used). Use {04 02 02} instead
++   02 - BZip
++      02 - BZip2
++   03 - Rar
++      01 - Rar15
++      02 - Rar20
++      03 - Rar29
++   04 - Arj
++      01 - Arj (1,2,3)
++      02 - Arj 4
++   05 - Z
++   06 - Lzh
++   07 - Reserved for 7z
++   08 - Cab
++   09 - NSIS
++      01 - DeflateNSIS
++      02 - BZip2NSIS
++
++
++06 - Crypto 
++   00 - 
++   01 - AES
++      0x - AES-128
++      4x - AES-192
++      8x - AES-256
++      Cx - AES
++
++      x0 - ECB
++      x1 - CBC
++      x2 - CFB
++      x3 - OFB
++
++   07 - Reserved
++   0F - Reserved
++
++   F0 - Misc Ciphers (Real Ciphers without hashing algo)
++
++   F1 - Misc Ciphers (Combine)
++      01 - Zip
++         01 - Main Zip crypto algo
++      03 - RAR
++         02 - 
++         03 - Rar29 AES-128 + (modified SHA-1)
++      07 - 7z
++         01 - AES-256 + SHA-256
++
++07 - Hash (subject to change)
++   00 - 
++   01 - CRC
++   02 - SHA-1
++   03 - SHA-256
++   04 - SHA-384
++   05 - SHA-512
++
++   F0 - Misc Hash
++
++   F1 - Misc
++      03 - RAR
++         03 - Rar29 Password Hashing (modified SHA1)
++      07 - 7z 
++         01 - SHA-256 Password Hashing
++    
++   
++
++
++---
++End of document
+diff --git a/squashfs-tools/LZMA/lzma465/history.txt b/squashfs-tools/LZMA/lzma465/history.txt
+new file mode 100644
+index 0000000..f5b129f
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/history.txt
 @@ -0,0 +1,236 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -12526,7 +12296,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashf
 +
 +4.57           2007-12-12
 +-------------------------
-+- Speed optimizations in Ñ++ LZMA Decoder. 
++- Speed optimizations in ï¿½++ LZMA Decoder. 
 +- Small changes for more compatibility with some C/C++ compilers.
 +
 +
@@ -12719,9 +12489,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashf
 +  
 +
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-tools-patched/LZMA/lzma465/lzma.txt
---- squashfs-tools/LZMA/lzma465/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzma465/lzma.txt b/squashfs-tools/LZMA/lzma465/lzma.txt
+new file mode 100644
+index 0000000..715792d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzma465/lzma.txt
 @@ -0,0 +1,594 @@
 +LZMA SDK 4.65
 +-------------
@@ -13317,150 +13089,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-t
 +http://www.7-zip.org
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashfs-tools-patched/LZMA/lzma465/Methods.txt
---- squashfs-tools/LZMA/lzma465/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,137 @@
-+7-Zip method IDs (4.65)
-+-----------------------
-+
-+Each compression or crypto method in 7z has unique binary value (ID).
-+The length of ID in bytes is arbitrary but it can not exceed 63 bits (8 bytes).
-+
-+If you want to add some new ID, you have two ways:
-+1) Write request for allocating IDs to 7-zip developers.
-+2) Generate 8-bytes ID:
-+
-+    3F ZZ ZZ ZZ ZZ ZZ MM MM 
-+
-+    3F              - Prefix for random IDs (1 byte)
-+    ZZ ZZ ZZ ZZ ZZ  - Developer ID (5 bytes). Use real random bytes. 
-+                      
-+    MM MM           - Method ID (2 bytes)
-+
-+    You can notify 7-Zip developers about your Developer ID / Method ID.
-+
-+    Note: Use new ID only if old codec can not decode data encoded with new version.
-+
-+
-+List of defined IDs
-+-------------------
-+      
-+00 - Copy
-+
-+02 - Common
-+   03 Swap
-+      - 2 Swap2
-+      - 4 Swap4
-+
-+03 - 7z
-+   01 - LZMA
-+      01 - Version
-+  
-+   03 - Branch
-+      01 - x86
-+         03  - BCJ
-+         1B  - BCJ2
-+      02 - PPC
-+         05 - PPC (Big Endian)
-+      03 - Alpha
-+         01 - Alpha
-+      04 - IA64
-+         01 - IA64
-+      05 - ARM
-+         01 - ARM
-+      06 - M68
-+         05 - M68 (Big Endian)
-+      07 - ARM Thumb
-+         01 - ARMT
-+      08 - SPARC
-+         05 - SPARC
-+
-+   04 - PPMD
-+      01 - Version
-+
-+   7F -
-+      01 - experimental methods.
-+
-+
-+04 - Misc
-+   00 - Reserved
-+   01 - Zip
-+      00 - Copy (not used). Use {00} instead
-+      01 - Shrink
-+      06 - Implode
-+      08 - Deflate
-+      09 - Deflate64
-+      12 - BZip2 (not used). Use {04 02 02} instead
-+   02 - BZip
-+      02 - BZip2
-+   03 - Rar
-+      01 - Rar15
-+      02 - Rar20
-+      03 - Rar29
-+   04 - Arj
-+      01 - Arj (1,2,3)
-+      02 - Arj 4
-+   05 - Z
-+   06 - Lzh
-+   07 - Reserved for 7z
-+   08 - Cab
-+   09 - NSIS
-+      01 - DeflateNSIS
-+      02 - BZip2NSIS
-+
-+
-+06 - Crypto 
-+   00 - 
-+   01 - AES
-+      0x - AES-128
-+      4x - AES-192
-+      8x - AES-256
-+      Cx - AES
-+
-+      x0 - ECB
-+      x1 - CBC
-+      x2 - CFB
-+      x3 - OFB
-+
-+   07 - Reserved
-+   0F - Reserved
-+
-+   F0 - Misc Ciphers (Real Ciphers without hashing algo)
-+
-+   F1 - Misc Ciphers (Combine)
-+      01 - Zip
-+         01 - Main Zip crypto algo
-+      03 - RAR
-+         02 - 
-+         03 - Rar29 AES-128 + (modified SHA-1)
-+      07 - 7z
-+         01 - AES-256 + SHA-256
-+
-+07 - Hash (subject to change)
-+   00 - 
-+   01 - CRC
-+   02 - SHA-1
-+   03 - SHA-256
-+   04 - SHA-384
-+   05 - SHA-512
-+
-+   F0 - Misc Hash
-+
-+   F1 - Misc
-+      03 - RAR
-+         03 - Rar29 Password Hashing (modified SHA1)
-+      07 - 7z 
-+         01 - SHA-256 Password Hashing
-+    
-+   
-+
-+
-+---
-+End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt
---- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/7zC.txt b/squashfs-tools/LZMA/lzmadaptive/7zC.txt
+new file mode 100644
+index 0000000..bac297f
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/7zC.txt
 @@ -0,0 +1,235 @@
 +7z ANSI-C Decoder 4.23
 +----------------------
@@ -13697,9 +13330,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashf
 +
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt
---- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2016-08-25 09:06:03.223530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/7zFormat.txt b/squashfs-tools/LZMA/lzmadaptive/7zFormat.txt
+new file mode 100644
+index 0000000..56ff817
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/7zFormat.txt
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -14172,9 +13807,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt sq
 +
 +---
 +End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
+new file mode 100644
+index 0000000..21bb30c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
 @@ -0,0 +1,70 @@
 +/* 7zAlloc.c */
 +
@@ -14246,9 +13883,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  #endif
 +  free(address);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
+new file mode 100644
+index 0000000..4ca4170
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
 @@ -0,0 +1,20 @@
 +/* 7zAlloc.h */
 +
@@ -14270,9 +13909,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +void SzFreeTemp(void *address);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
+new file mode 100644
+index 0000000..3c4b71e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
 @@ -0,0 +1,29 @@
 +/* 7zBuffer.c */
 +
@@ -14303,9 +13944,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  buffer->Items = 0;
 +  buffer->Capacity = 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
+new file mode 100644
+index 0000000..17e5906
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
 @@ -0,0 +1,19 @@
 +/* 7zBuffer.h */
 +
@@ -14326,224 +13969,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +void SzByteBufferFree(CSzByteBuffer *buffer, void (*freeFunc)(void *));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,178 @@
-+# Microsoft Developer Studio Project File - Name="7z_C" - Package Owner=<4>
-+# Microsoft Developer Studio Generated Build File, Format Version 6.00
-+# ** DO NOT EDIT **
-+
-+# TARGTYPE "Win32 (x86) Console Application" 0x0103
-+
-+CFG=7z_C - Win32 Debug
-+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
-+!MESSAGE use the Export Makefile command and run
-+!MESSAGE 
-+!MESSAGE NMAKE /f "7z_C.mak".
-+!MESSAGE 
-+!MESSAGE You can specify a configuration when running NMAKE
-+!MESSAGE by defining the macro CFG on the command line. For example:
-+!MESSAGE 
-+!MESSAGE NMAKE /f "7z_C.mak" CFG="7z_C - Win32 Debug"
-+!MESSAGE 
-+!MESSAGE Possible choices for configuration are:
-+!MESSAGE 
-+!MESSAGE "7z_C - Win32 Release" (based on "Win32 (x86) Console Application")
-+!MESSAGE "7z_C - Win32 Debug" (based on "Win32 (x86) Console Application")
-+!MESSAGE 
-+
-+# Begin Project
-+# PROP AllowPerConfigDependencies 0
-+# PROP Scc_ProjName ""
-+# PROP Scc_LocalPath ""
-+CPP=cl.exe
-+RSC=rc.exe
-+
-+!IF  "$(CFG)" == "7z_C - Win32 Release"
-+
-+# PROP BASE Use_MFC 0
-+# PROP BASE Use_Debug_Libraries 0
-+# PROP BASE Output_Dir "Release"
-+# PROP BASE Intermediate_Dir "Release"
-+# PROP BASE Target_Dir ""
-+# PROP Use_MFC 0
-+# PROP Use_Debug_Libraries 0
-+# PROP Output_Dir "Release"
-+# PROP Intermediate_Dir "Release"
-+# PROP Ignore_Export_Lib 0
-+# PROP Target_Dir ""
-+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
-+# ADD CPP /nologo /W4 /GX /O2 /D "NDEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "_LZMA_PROB32" /D "_LZMA_IN_CB" /YX /FD /c
-+# ADD BASE RSC /l 0x419 /d "NDEBUG"
-+# ADD RSC /l 0x419 /d "NDEBUG"
-+BSC32=bscmake.exe
-+# ADD BASE BSC32 /nologo
-+# ADD BSC32 /nologo
-+LINK32=link.exe
-+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
-+# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386 /out:"Release/7zDec.exe"
-+
-+!ELSEIF  "$(CFG)" == "7z_C - Win32 Debug"
-+
-+# PROP BASE Use_MFC 0
-+# PROP BASE Use_Debug_Libraries 1
-+# PROP BASE Output_Dir "Debug"
-+# PROP BASE Intermediate_Dir "Debug"
-+# PROP BASE Target_Dir ""
-+# PROP Use_MFC 0
-+# PROP Use_Debug_Libraries 1
-+# PROP Output_Dir "Debug"
-+# PROP Intermediate_Dir "Debug"
-+# PROP Ignore_Export_Lib 0
-+# PROP Target_Dir ""
-+# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
-+# ADD CPP /nologo /W3 /Gm /GX /ZI /Od /D "_DEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "_LZMA_PROB32" /D "_LZMA_IN_CB" /YX /FD /GZ /c
-+# ADD BASE RSC /l 0x419 /d "_DEBUG"
-+# ADD RSC /l 0x419 /d "_DEBUG"
-+BSC32=bscmake.exe
-+# ADD BASE BSC32 /nologo
-+# ADD BSC32 /nologo
-+LINK32=link.exe
-+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
-+# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /out:"Debug/7zDec.exe" /pdbtype:sept
-+
-+!ENDIF 
-+
-+# Begin Target
-+
-+# Name "7z_C - Win32 Release"
-+# Name "7z_C - Win32 Debug"
-+# Begin Group "LZMA"
-+
-+# PROP Default_Filter ""
-+# Begin Source File
-+
-+SOURCE=..\..\Compress\LZMA_C\LzmaDecode.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=..\..\Compress\LZMA_C\LzmaDecode.h
-+# End Source File
-+# End Group
-+# Begin Source File
-+
-+SOURCE=.\7zAlloc.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zAlloc.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zBuffer.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zBuffer.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zCrc.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zCrc.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zDecode.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zDecode.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zExtract.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zExtract.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zHeader.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zHeader.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zIn.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zIn.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zItem.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zItem.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zMain.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zMethodID.c
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zMethodID.h
-+# End Source File
-+# Begin Source File
-+
-+SOURCE=.\7zTypes.h
-+# End Source File
-+# End Target
-+# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,29 @@
-+Microsoft Developer Studio Workspace File, Format Version 6.00
-+# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
-+
-+###############################################################################
-+
-+Project: "7z_C"=.\7z_C.dsp - Package Owner=<4>
-+
-+Package=<5>
-+{{{
-+}}}
-+
-+Package=<4>
-+{{{
-+}}}
-+
-+###############################################################################
-+
-+Global:
-+
-+Package=<5>
-+{{{
-+}}}
-+
-+Package=<3>
-+{{{
-+}}}
-+
-+###############################################################################
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
+new file mode 100644
+index 0000000..9773840
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
 @@ -0,0 +1,76 @@
 +/* 7zCrc.c */
 +
@@ -14621,9 +14051,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +{
 +  return (CrcCalculateDigest(data, size) == digest);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
+new file mode 100644
+index 0000000..adcc563
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h */
 +
@@ -14649,9 +14081,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +int CrcVerifyDigest(UInt32 digest, const void *data, size_t size);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
+new file mode 100644
+index 0000000..b42ff92
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
 @@ -0,0 +1,150 @@
 +/* 7zDecode.c */
 +
@@ -14803,9 +14237,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  }
 +  return SZE_NOTIMPL;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
+new file mode 100644
+index 0000000..74bb180
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
 @@ -0,0 +1,21 @@
 +/* 7zDecode.h */
 +
@@ -14828,9 +14264,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    size_t *outSizeProcessed, ISzAlloc *allocMain);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
+new file mode 100644
+index 0000000..6ef872c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
 @@ -0,0 +1,116 @@
 +/* 7zExtract.c */
 +
@@ -14948,9 +14386,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  }
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
+new file mode 100644
+index 0000000..e9a4fb4
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
 @@ -0,0 +1,40 @@
 +/* 7zExtract.h */
 +
@@ -14992,18 +14432,22 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    ISzAlloc *allocTemp);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
+new file mode 100644
+index 0000000..3be4bc2
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
 @@ -0,0 +1,5 @@
 +/*  7zHeader.c */
 +
 +#include "7zHeader.h"
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
+new file mode 100644
+index 0000000..0356aaa
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
 @@ -0,0 +1,55 @@
 +/* 7zHeader.h */
 +
@@ -15060,9 +14504,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
+new file mode 100644
+index 0000000..2eea571
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
 @@ -0,0 +1,1292 @@
 +/* 7zIn.c */
 +
@@ -16356,9 +15802,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    SzArDbExFree(db, allocMain->Free);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
+new file mode 100644
+index 0000000..6bfa2a7
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
 @@ -0,0 +1,55 @@
 +/* 7zIn.h */
 +
@@ -16415,9 +15863,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    ISzAlloc *allocTemp);
 + 
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
+new file mode 100644
+index 0000000..2a40805
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
 @@ -0,0 +1,133 @@
 +/* 7zItem.c */
 +
@@ -16552,9 +16002,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  freeFunc(db->Files);
 +  SzArchiveDatabaseInit(db);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
+new file mode 100644
+index 0000000..876539a
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
 @@ -0,0 +1,90 @@
 +/* 7zItem.h */
 +
@@ -16646,9 +16098,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
+new file mode 100644
+index 0000000..d5c5ed9
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
 @@ -0,0 +1,223 @@
 +/* 
 +7zMain.c
@@ -16873,9 +16327,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +    printf("\nERROR #%d\n", res);
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
+new file mode 100644
+index 0000000..5047359
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
 @@ -0,0 +1,14 @@
 +/* 7zMethodID.c */
 +
@@ -16891,9 +16347,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +      return 0;
 +  return 1;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
+new file mode 100644
+index 0000000..162fcd1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
 @@ -0,0 +1,18 @@
 +/* 7zMethodID.h */
 +
@@ -16913,9 +16371,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +int AreMethodsEqual(CMethodID *a1, CMethodID *a2);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
+new file mode 100644
+index 0000000..fdef145
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
 @@ -0,0 +1,61 @@
 +/* 7zTypes.h */
 +
@@ -16978,9 +16438,230 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#define RINOK(x) { int __result_ = (x); if(__result_ != 0) return __result_; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
+new file mode 100644
+index 0000000..1e87152
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
+@@ -0,0 +1,178 @@
++# Microsoft Developer Studio Project File - Name="7z_C" - Package Owner=<4>
++# Microsoft Developer Studio Generated Build File, Format Version 6.00
++# ** DO NOT EDIT **
++
++# TARGTYPE "Win32 (x86) Console Application" 0x0103
++
++CFG=7z_C - Win32 Debug
++!MESSAGE This is not a valid makefile. To build this project using NMAKE,
++!MESSAGE use the Export Makefile command and run
++!MESSAGE 
++!MESSAGE NMAKE /f "7z_C.mak".
++!MESSAGE 
++!MESSAGE You can specify a configuration when running NMAKE
++!MESSAGE by defining the macro CFG on the command line. For example:
++!MESSAGE 
++!MESSAGE NMAKE /f "7z_C.mak" CFG="7z_C - Win32 Debug"
++!MESSAGE 
++!MESSAGE Possible choices for configuration are:
++!MESSAGE 
++!MESSAGE "7z_C - Win32 Release" (based on "Win32 (x86) Console Application")
++!MESSAGE "7z_C - Win32 Debug" (based on "Win32 (x86) Console Application")
++!MESSAGE 
++
++# Begin Project
++# PROP AllowPerConfigDependencies 0
++# PROP Scc_ProjName ""
++# PROP Scc_LocalPath ""
++CPP=cl.exe
++RSC=rc.exe
++
++!IF  "$(CFG)" == "7z_C - Win32 Release"
++
++# PROP BASE Use_MFC 0
++# PROP BASE Use_Debug_Libraries 0
++# PROP BASE Output_Dir "Release"
++# PROP BASE Intermediate_Dir "Release"
++# PROP BASE Target_Dir ""
++# PROP Use_MFC 0
++# PROP Use_Debug_Libraries 0
++# PROP Output_Dir "Release"
++# PROP Intermediate_Dir "Release"
++# PROP Ignore_Export_Lib 0
++# PROP Target_Dir ""
++# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /c
++# ADD CPP /nologo /W4 /GX /O2 /D "NDEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "_LZMA_PROB32" /D "_LZMA_IN_CB" /YX /FD /c
++# ADD BASE RSC /l 0x419 /d "NDEBUG"
++# ADD RSC /l 0x419 /d "NDEBUG"
++BSC32=bscmake.exe
++# ADD BASE BSC32 /nologo
++# ADD BSC32 /nologo
++LINK32=link.exe
++# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
++# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386 /out:"Release/7zDec.exe"
++
++!ELSEIF  "$(CFG)" == "7z_C - Win32 Debug"
++
++# PROP BASE Use_MFC 0
++# PROP BASE Use_Debug_Libraries 1
++# PROP BASE Output_Dir "Debug"
++# PROP BASE Intermediate_Dir "Debug"
++# PROP BASE Target_Dir ""
++# PROP Use_MFC 0
++# PROP Use_Debug_Libraries 1
++# PROP Output_Dir "Debug"
++# PROP Intermediate_Dir "Debug"
++# PROP Ignore_Export_Lib 0
++# PROP Target_Dir ""
++# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_CONSOLE" /D "_MBCS" /YX /FD /GZ /c
++# ADD CPP /nologo /W3 /Gm /GX /ZI /Od /D "_DEBUG" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "_LZMA_PROB32" /D "_LZMA_IN_CB" /YX /FD /GZ /c
++# ADD BASE RSC /l 0x419 /d "_DEBUG"
++# ADD RSC /l 0x419 /d "_DEBUG"
++BSC32=bscmake.exe
++# ADD BASE BSC32 /nologo
++# ADD BSC32 /nologo
++LINK32=link.exe
++# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
++# ADD LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /out:"Debug/7zDec.exe" /pdbtype:sept
++
++!ENDIF 
++
++# Begin Target
++
++# Name "7z_C - Win32 Release"
++# Name "7z_C - Win32 Debug"
++# Begin Group "LZMA"
++
++# PROP Default_Filter ""
++# Begin Source File
++
++SOURCE=..\..\Compress\LZMA_C\LzmaDecode.c
++# End Source File
++# Begin Source File
++
++SOURCE=..\..\Compress\LZMA_C\LzmaDecode.h
++# End Source File
++# End Group
++# Begin Source File
++
++SOURCE=.\7zAlloc.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zAlloc.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zBuffer.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zBuffer.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zCrc.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zCrc.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zDecode.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zDecode.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zExtract.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zExtract.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zHeader.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zHeader.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zIn.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zIn.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zItem.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zItem.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zMain.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zMethodID.c
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zMethodID.h
++# End Source File
++# Begin Source File
++
++SOURCE=.\7zTypes.h
++# End Source File
++# End Target
++# End Project
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
+new file mode 100644
+index 0000000..6fd3962
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
+@@ -0,0 +1,29 @@
++Microsoft Developer Studio Workspace File, Format Version 6.00
++# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
++
++###############################################################################
++
++Project: "7z_C"=.\7z_C.dsp - Package Owner=<4>
++
++Package=<5>
++{{{
++}}}
++
++Package=<4>
++{{{
++}}}
++
++###############################################################################
++
++Global:
++
++Package=<5>
++{{{
++}}}
++
++Package=<3>
++{{{
++}}}
++
++###############################################################################
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
+new file mode 100644
+index 0000000..9ce2c34
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
 @@ -0,0 +1,55 @@
 +PROG = 7zDec.exe
 +
@@ -17037,9 +16718,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +	$(COMPL)
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
+new file mode 100644
+index 0000000..21b7df4
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
 @@ -0,0 +1,50 @@
 +PROG = 7zDec
 +CXX = g++
@@ -17091,9 +16774,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
+new file mode 100644
+index 0000000..8a000e4
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
 @@ -0,0 +1,251 @@
 +// FileStreams.cpp
 +
@@ -17346,9 +17031,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +}
 +  
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
+new file mode 100644
+index 0000000..9326372
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
 @@ -0,0 +1,98 @@
 +// FileStreams.h
 +
@@ -17448,9 +17135,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
+new file mode 100644
+index 0000000..02f2adf
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
 @@ -0,0 +1,80 @@
 +// InBuffer.cpp
 +
@@ -17532,9 +17221,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +    return 0xFF;
 +  return *_buffer++;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
+new file mode 100644
+index 0000000..057caa1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
 @@ -0,0 +1,76 @@
 +// InBuffer.h
 +
@@ -17612,9 +17303,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
+new file mode 100644
+index 0000000..f4ec1a3
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
 @@ -0,0 +1,117 @@
 +// OutByte.cpp
 +
@@ -17733,9 +17426,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +    throw COutBufferException(result);
 +  #endif
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
+new file mode 100644
+index 0000000..0ce54e2
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
 @@ -0,0 +1,64 @@
 +// OutBuffer.h
 +
@@ -17801,9 +17496,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
+new file mode 100644
+index 0000000..27a77b1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -17814,9 +17511,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +#include "../../Common/NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
+new file mode 100644
+index 0000000..a5d9ac0
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
 @@ -0,0 +1,44 @@
 +// StreamUtils.cpp
 +
@@ -17862,9 +17561,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +  }
 +  return S_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
+new file mode 100644
+index 0000000..59f8873
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
 @@ -0,0 +1,11 @@
 +// StreamUtils.h
 +
@@ -17877,9 +17578,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +HRESULT WriteStream(ISequentialOutStream *stream, const void *data, UInt32 size, UInt32 *processedSize);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
+new file mode 100644
+index 0000000..4bd5e18
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
 @@ -0,0 +1,16 @@
 +// ARM.cpp
 +
@@ -17897,9 +17600,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::ARM_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
+new file mode 100644
+index 0000000..5561299
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
 @@ -0,0 +1,10 @@
 +// ARM.h
 +
@@ -17911,9 +17616,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_ARM, 0x05, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
+new file mode 100644
+index 0000000..fbd2570
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
 @@ -0,0 +1,16 @@
 +// ARMThumb.cpp
 +
@@ -17931,9 +17638,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::ARMThumb_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
+new file mode 100644
+index 0000000..601e40b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
 @@ -0,0 +1,10 @@
 +// ARMThumb.h
 +
@@ -17945,9 +17654,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_ARMThumb, 0x07, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
+new file mode 100644
+index 0000000..7e0bbf8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
 @@ -0,0 +1,26 @@
 +// BranchARM.c
 +
@@ -17975,9 +17686,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
+new file mode 100644
+index 0000000..5140a17
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
 @@ -0,0 +1,10 @@
 +// BranchARM.h
 +
@@ -17989,9 +17702,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 ARM_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
+new file mode 100644
+index 0000000..d30b75c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
 @@ -0,0 +1,35 @@
 +// BranchARMThumb.c
 +
@@ -18028,9 +17743,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
+new file mode 100644
+index 0000000..0f177b6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
 @@ -0,0 +1,10 @@
 +// BranchARMThumb.h
 +
@@ -18042,9 +17759,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 ARMThumb_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
+new file mode 100644
+index 0000000..8d25f0d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
 @@ -0,0 +1,18 @@
 +// BranchCoder.cpp
 +
@@ -18064,9 +17783,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  _bufferPos += processedSize;
 +  return processedSize;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
+new file mode 100644
+index 0000000..4b53b6c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
 @@ -0,0 +1,54 @@
 +// BranchCoder.h
 +
@@ -18122,9 +17843,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassDecoderB(Name ## _Decoder, ADD_ITEMS, ADD_INIT)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
+new file mode 100644
+index 0000000..55c03fa
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
 @@ -0,0 +1,65 @@
 +// BranchIA64.c
 +
@@ -18191,9 +17914,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
+new file mode 100644
+index 0000000..0ad98ba
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
 @@ -0,0 +1,10 @@
 +// BranchIA64.h
 +
@@ -18205,9 +17930,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 IA64_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
+new file mode 100644
+index 0000000..eb3aafb
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
 @@ -0,0 +1,36 @@
 +// BranchPPC.c
 +
@@ -18245,9 +17972,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
+new file mode 100644
+index 0000000..1c4dca7
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
 @@ -0,0 +1,10 @@
 +// BranchPPC.h
 +
@@ -18259,9 +17988,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 PPC_B_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
+new file mode 100644
+index 0000000..a8d3f4d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
 @@ -0,0 +1,36 @@
 +// BranchSPARC.c
 +
@@ -18299,9 +18030,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return i;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
+new file mode 100644
+index 0000000..dafa40d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
 @@ -0,0 +1,10 @@
 +// BranchSPARC.h
 +
@@ -18313,9 +18046,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +UInt32 SPARC_B_Convert(Byte *data, UInt32 size, UInt32 nowPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
+new file mode 100644
+index 0000000..2c6f69a
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
 @@ -0,0 +1,101 @@
 +/* BranchX86.c */
 +
@@ -18418,9 +18153,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return bufferPos;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
+new file mode 100644
+index 0000000..b7217ed
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
 @@ -0,0 +1,19 @@
 +/* BranchX86.h */
 +
@@ -18441,9 +18178,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    UInt32 *prevMask, UInt32 *prevPos, int encoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
+new file mode 100644
+index 0000000..75dfdcb
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
 @@ -0,0 +1,16 @@
 +// IA64.cpp
 +
@@ -18461,9 +18200,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::IA64_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
+new file mode 100644
+index 0000000..7fe715e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
 @@ -0,0 +1,10 @@
 +// IA64.h
 +
@@ -18475,9 +18216,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_IA64, 0x04, 1)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
+new file mode 100644
+index 0000000..197a8e5
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
 @@ -0,0 +1,17 @@
 +// PPC.cpp
 +
@@ -18496,9 +18239,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::PPC_B_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
+new file mode 100644
+index 0000000..a0e3344
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
 @@ -0,0 +1,10 @@
 +// PPC.h
 +
@@ -18510,9 +18255,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_PPC_B, 0x02, 5)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
+new file mode 100644
+index 0000000..d054eaa
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
 @@ -0,0 +1,17 @@
 +// SPARC.cpp
 +
@@ -18531,9 +18278,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +{
 +  return ::SPARC_Convert(data, size, _bufferPos, 0);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
+new file mode 100644
+index 0000000..e0a682e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
 @@ -0,0 +1,10 @@
 +// SPARC.h
 +
@@ -18545,9 +18294,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +MyClassA(BC_SPARC, 0x08, 5)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
+new file mode 100644
+index 0000000..e7fb698
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -18557,9 +18308,60 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
+new file mode 100644
+index 0000000..013e42b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
+@@ -0,0 +1,18 @@
++// x86.cpp
++
++#include "StdAfx.h"
++#include "x86.h"
++
++#include "Windows/Defs.h"
++
++#include "BranchX86.c"
++
++UInt32 CBCJ_x86_Encoder::SubFilter(Byte *data, UInt32 size)
++{
++  return ::x86_Convert(data, size, _bufferPos, &_prevMask, &_prevPos, 1);
++}
++
++UInt32 CBCJ_x86_Decoder::SubFilter(Byte *data, UInt32 size)
++{
++  return ::x86_Convert(data, size, _bufferPos, &_prevMask, &_prevPos, 0);
++}
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
+new file mode 100644
+index 0000000..10d0398
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
+@@ -0,0 +1,19 @@
++// x86.h
++
++#ifndef __X86_H
++#define __X86_H
++
++#include "BranchCoder.h"
++#include "BranchX86.h"
++
++struct CBranch86
++{
++  UInt32 _prevMask;
++  UInt32 _prevPos;
++  void x86Init() { x86_Convert_Init(_prevMask, _prevPos); }
++};
++
++MyClassB(BCJ_x86, 0x01, 3, CBranch86 , 
++    virtual void SubInit() { x86Init(); })
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
+new file mode 100644
+index 0000000..8f7bff2
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
 @@ -0,0 +1,412 @@
 +// x86_2.cpp
 +
@@ -18973,9 +18775,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  catch(const COutBufferException &e) { return e.ErrorCode; }
 +  catch(...) { return S_FALSE; }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
+new file mode 100644
+index 0000000..3d34eb8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
 @@ -0,0 +1,133 @@
 +// x86_2.h
 +
@@ -19110,156 +18914,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}; 
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,18 @@
-+// x86.cpp
-+
-+#include "StdAfx.h"
-+#include "x86.h"
-+
-+#include "Windows/Defs.h"
-+
-+#include "BranchX86.c"
-+
-+UInt32 CBCJ_x86_Encoder::SubFilter(Byte *data, UInt32 size)
-+{
-+  return ::x86_Convert(data, size, _bufferPos, &_prevMask, &_prevPos, 1);
-+}
-+
-+UInt32 CBCJ_x86_Decoder::SubFilter(Byte *data, UInt32 size)
-+{
-+  return ::x86_Convert(data, size, _bufferPos, &_prevMask, &_prevPos, 0);
-+}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,19 @@
-+// x86.h
-+
-+#ifndef __X86_H
-+#define __X86_H
-+
-+#include "BranchCoder.h"
-+#include "BranchX86.h"
-+
-+struct CBranch86
-+{
-+  UInt32 _prevMask;
-+  UInt32 _prevPos;
-+  void x86Init() { x86_Convert_Init(_prevMask, _prevPos); }
-+};
-+
-+MyClassB(BCJ_x86, 0x01, 3, CBranch86 , 
-+    virtual void SubInit() { x86Init(); })
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,12 @@
-+// BinTree2.h
-+
-+#ifndef __BINTREE2_H
-+#define __BINTREE2_H
-+
-+#undef BT_NAMESPACE
-+#define BT_NAMESPACE NBT2
-+
-+#include "BinTree.h"
-+#include "BinTreeMain.h"
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,16 @@
-+// BinTree3.h
-+
-+#ifndef __BINTREE3_H
-+#define __BINTREE3_H
-+
-+#undef BT_NAMESPACE
-+#define BT_NAMESPACE NBT3
-+
-+#define HASH_ARRAY_2
-+
-+#include "BinTree.h"
-+#include "BinTreeMain.h"
-+
-+#undef HASH_ARRAY_2
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,16 @@
-+// BinTree3Z.h
-+
-+#ifndef __BINTREE3Z_H
-+#define __BINTREE3Z_H
-+
-+#undef BT_NAMESPACE
-+#define BT_NAMESPACE NBT3Z
-+
-+#define HASH_ZIP
-+
-+#include "BinTree.h"
-+#include "BinTreeMain.h"
-+
-+#undef HASH_ZIP
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,20 @@
-+// BinTree4b.h
-+
-+#ifndef __BINTREE4B_H
-+#define __BINTREE4B_H
-+
-+#undef BT_NAMESPACE
-+#define BT_NAMESPACE NBT4B
-+
-+#define HASH_ARRAY_2
-+#define HASH_ARRAY_3
-+#define HASH_BIG
-+
-+#include "BinTree.h"
-+#include "BinTreeMain.h"
-+
-+#undef HASH_ARRAY_2
-+#undef HASH_ARRAY_3
-+#undef HASH_BIG
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,18 @@
-+// BinTree4.h
-+
-+#ifndef __BINTREE4_H
-+#define __BINTREE4_H
-+
-+#undef BT_NAMESPACE
-+#define BT_NAMESPACE NBT4
-+
-+#define HASH_ARRAY_2
-+#define HASH_ARRAY_3
-+
-+#include "BinTree.h"
-+#include "BinTreeMain.h"
-+
-+#undef HASH_ARRAY_2
-+#undef HASH_ARRAY_3
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
+new file mode 100644
+index 0000000..dea1a73
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
 @@ -0,0 +1,55 @@
 +// BinTree.h
 +
@@ -19316,9 +18975,123 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
+new file mode 100644
+index 0000000..03ac826
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
+@@ -0,0 +1,12 @@
++// BinTree2.h
++
++#ifndef __BINTREE2_H
++#define __BINTREE2_H
++
++#undef BT_NAMESPACE
++#define BT_NAMESPACE NBT2
++
++#include "BinTree.h"
++#include "BinTreeMain.h"
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
+new file mode 100644
+index 0000000..f662c0e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
+@@ -0,0 +1,16 @@
++// BinTree3.h
++
++#ifndef __BINTREE3_H
++#define __BINTREE3_H
++
++#undef BT_NAMESPACE
++#define BT_NAMESPACE NBT3
++
++#define HASH_ARRAY_2
++
++#include "BinTree.h"
++#include "BinTreeMain.h"
++
++#undef HASH_ARRAY_2
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
+new file mode 100644
+index 0000000..60a52e8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
+@@ -0,0 +1,16 @@
++// BinTree3Z.h
++
++#ifndef __BINTREE3Z_H
++#define __BINTREE3Z_H
++
++#undef BT_NAMESPACE
++#define BT_NAMESPACE NBT3Z
++
++#define HASH_ZIP
++
++#include "BinTree.h"
++#include "BinTreeMain.h"
++
++#undef HASH_ZIP
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
+new file mode 100644
+index 0000000..7edcc07
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
+@@ -0,0 +1,18 @@
++// BinTree4.h
++
++#ifndef __BINTREE4_H
++#define __BINTREE4_H
++
++#undef BT_NAMESPACE
++#define BT_NAMESPACE NBT4
++
++#define HASH_ARRAY_2
++#define HASH_ARRAY_3
++
++#include "BinTree.h"
++#include "BinTreeMain.h"
++
++#undef HASH_ARRAY_2
++#undef HASH_ARRAY_3
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
+new file mode 100644
+index 0000000..3f5434c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
+@@ -0,0 +1,20 @@
++// BinTree4b.h
++
++#ifndef __BINTREE4B_H
++#define __BINTREE4B_H
++
++#undef BT_NAMESPACE
++#define BT_NAMESPACE NBT4B
++
++#define HASH_ARRAY_2
++#define HASH_ARRAY_3
++#define HASH_BIG
++
++#include "BinTree.h"
++#include "BinTreeMain.h"
++
++#undef HASH_ARRAY_2
++#undef HASH_ARRAY_3
++#undef HASH_BIG
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
+new file mode 100644
+index 0000000..21ba1d7
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
 @@ -0,0 +1,444 @@
 +// BinTreeMain.h
 +
@@ -19764,95 +19537,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 + 
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,13 @@
-+// HC2.h
-+
-+#ifndef __HC2_H
-+#define __HC2_H
-+
-+#undef HC_NAMESPACE
-+#define HC_NAMESPACE NHC2
-+
-+#include "HCMF.h"
-+#include "HCMFMain.h"
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,17 @@
-+// HC3.h
-+
-+#ifndef __HC3_H
-+#define __HC3_H
-+
-+#undef HC_NAMESPACE
-+#define HC_NAMESPACE NHC3
-+
-+#define HASH_ARRAY_2
-+
-+#include "HC.h"
-+#include "HCMain.h"
-+
-+#undef HASH_ARRAY_2
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,21 @@
-+// HC4b.h
-+
-+#ifndef __HC4B__H
-+#define __HC4B__H
-+
-+#undef HC_NAMESPACE
-+#define HC_NAMESPACE NHC4b
-+
-+#define HASH_ARRAY_2
-+#define HASH_ARRAY_3
-+#define HASH_BIG
-+
-+#include "HC.h"
-+#include "HCMain.h"
-+
-+#undef HASH_ARRAY_2
-+#undef HASH_ARRAY_3
-+#undef HASH_BIG
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,19 @@
-+// HC4.h
-+
-+#ifndef __HC4_H
-+#define __HC4_H
-+
-+#undef HC_NAMESPACE
-+#define HC_NAMESPACE NHC4
-+
-+#define HASH_ARRAY_2
-+#define HASH_ARRAY_3
-+
-+#include "HC.h"
-+#include "HCMain.h"
-+
-+#undef HASH_ARRAY_2
-+#undef HASH_ARRAY_3
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
+new file mode 100644
+index 0000000..393bb8a
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
 @@ -0,0 +1,55 @@
 +// HC.h
 +
@@ -19909,9 +19598,105 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
+new file mode 100644
+index 0000000..e9f22e1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
+@@ -0,0 +1,13 @@
++// HC2.h
++
++#ifndef __HC2_H
++#define __HC2_H
++
++#undef HC_NAMESPACE
++#define HC_NAMESPACE NHC2
++
++#include "HCMF.h"
++#include "HCMFMain.h"
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
+new file mode 100644
+index 0000000..a9afd25
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
+@@ -0,0 +1,17 @@
++// HC3.h
++
++#ifndef __HC3_H
++#define __HC3_H
++
++#undef HC_NAMESPACE
++#define HC_NAMESPACE NHC3
++
++#define HASH_ARRAY_2
++
++#include "HC.h"
++#include "HCMain.h"
++
++#undef HASH_ARRAY_2
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
+new file mode 100644
+index 0000000..a88828d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
+@@ -0,0 +1,19 @@
++// HC4.h
++
++#ifndef __HC4_H
++#define __HC4_H
++
++#undef HC_NAMESPACE
++#define HC_NAMESPACE NHC4
++
++#define HASH_ARRAY_2
++#define HASH_ARRAY_3
++
++#include "HC.h"
++#include "HCMain.h"
++
++#undef HASH_ARRAY_2
++#undef HASH_ARRAY_3
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
+new file mode 100644
+index 0000000..e2df3ef
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
+@@ -0,0 +1,21 @@
++// HC4b.h
++
++#ifndef __HC4B__H
++#define __HC4B__H
++
++#undef HC_NAMESPACE
++#define HC_NAMESPACE NHC4b
++
++#define HASH_ARRAY_2
++#define HASH_ARRAY_3
++#define HASH_BIG
++
++#include "HC.h"
++#include "HCMain.h"
++
++#undef HASH_ARRAY_2
++#undef HASH_ARRAY_3
++#undef HASH_BIG
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
+new file mode 100644
+index 0000000..fe67e4f
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
 @@ -0,0 +1,350 @@
 +// HC.h
 +
@@ -20263,9 +20048,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 + 
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
+new file mode 100644
+index 0000000..bb42f60
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
 @@ -0,0 +1,63 @@
 +// MatchFinders/IMatchFinder.h
 +
@@ -20330,9 +20117,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +*/
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
+new file mode 100644
+index 0000000..6492880
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
 @@ -0,0 +1,102 @@
 +// LZInWindow.cpp
 +
@@ -20436,9 +20225,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  _buffer -= offset;
 +  AfterMoveBlock();
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
+new file mode 100644
+index 0000000..a9cb732
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
 @@ -0,0 +1,84 @@
 +// LZInWindow.h
 +
@@ -20524,9 +20315,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
+new file mode 100644
+index 0000000..e2d6aba
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
 @@ -0,0 +1,17 @@
 +// LZOutWindow.cpp
 +
@@ -20545,9 +20338,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
+new file mode 100644
+index 0000000..5387fdb
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
 @@ -0,0 +1,64 @@
 +// LZOutWindow.h
 +
@@ -20613,143 +20408,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,22 @@
-+// Pat2.h
-+
-+#ifndef __PAT2__H
-+#define __PAT2__H
-+
-+#undef PAT_CLSID
-+#define PAT_CLSID CLSID_CMatchFinderPat2
-+
-+#undef PAT_NAMESPACE
-+#define PAT_NAMESPACE NPat2
-+
-+#define __AUTO_REMOVE
-+#define __NODE_2_BITS
-+
-+#include "Pat.h"
-+#include "PatMain.h"
-+
-+#undef __AUTO_REMOVE
-+#undef  __NODE_2_BITS
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,24 @@
-+// Pat2H.h
-+
-+#ifndef __PAT2H__H
-+#define __PAT2H__H
-+
-+#undef PAT_CLSID
-+#define PAT_CLSID CLSID_CMatchFinderPat2H
-+
-+#undef PAT_NAMESPACE
-+#define PAT_NAMESPACE NPat2H
-+
-+#define __AUTO_REMOVE
-+#define __NODE_2_BITS
-+#define __HASH_3
-+
-+#include "Pat.h"
-+#include "PatMain.h"
-+
-+#undef __AUTO_REMOVE
-+#undef __NODE_2_BITS
-+#undef __HASH_3
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,20 @@
-+// Pat2R.h
-+
-+#ifndef __PAT2R__H
-+#define __PAT2R__H
-+
-+#undef PAT_CLSID
-+#define PAT_CLSID CLSID_CMatchFinderPat2R
-+
-+#undef PAT_NAMESPACE
-+#define PAT_NAMESPACE NPat2R
-+
-+#define __NODE_2_BITS
-+
-+#include "Pat.h"
-+#include "PatMain.h"
-+
-+#undef  __NODE_2_BITS
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,24 @@
-+// Pat3H.h
-+
-+#ifndef __PAT3H__H
-+#define __PAT3H__H
-+
-+#undef PAT_CLSID
-+#define PAT_CLSID CLSID_CMatchFinderPat3H
-+
-+#undef PAT_NAMESPACE
-+#define PAT_NAMESPACE NPat3H
-+
-+#define __AUTO_REMOVE
-+#define __NODE_3_BITS
-+#define __HASH_3
-+
-+#include "Pat.h"
-+#include "PatMain.h"
-+
-+#undef __AUTO_REMOVE
-+#undef __NODE_3_BITS
-+#undef __HASH_3
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,24 @@
-+// Pat4H.h
-+
-+#ifndef __PAT4H__H
-+#define __PAT4H__H
-+
-+#undef PAT_CLSID
-+#define PAT_CLSID CLSID_CMatchFinderPat4H
-+
-+#undef PAT_NAMESPACE
-+#define PAT_NAMESPACE NPat4H
-+
-+#define __AUTO_REMOVE
-+#define __NODE_4_BITS
-+#define __HASH_3
-+
-+#include "Pat.h"
-+#include "PatMain.h"
-+
-+#undef __AUTO_REMOVE
-+#undef __NODE_4_BITS
-+#undef __HASH_3
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
+new file mode 100644
+index 0000000..f2eae09
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
 @@ -0,0 +1,318 @@
 +// Pat.h
 +
@@ -21069,9 +20732,155 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +// #endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
+new file mode 100644
+index 0000000..23b3cae
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
+@@ -0,0 +1,22 @@
++// Pat2.h
++
++#ifndef __PAT2__H
++#define __PAT2__H
++
++#undef PAT_CLSID
++#define PAT_CLSID CLSID_CMatchFinderPat2
++
++#undef PAT_NAMESPACE
++#define PAT_NAMESPACE NPat2
++
++#define __AUTO_REMOVE
++#define __NODE_2_BITS
++
++#include "Pat.h"
++#include "PatMain.h"
++
++#undef __AUTO_REMOVE
++#undef  __NODE_2_BITS
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
+new file mode 100644
+index 0000000..dd3963d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
+@@ -0,0 +1,24 @@
++// Pat2H.h
++
++#ifndef __PAT2H__H
++#define __PAT2H__H
++
++#undef PAT_CLSID
++#define PAT_CLSID CLSID_CMatchFinderPat2H
++
++#undef PAT_NAMESPACE
++#define PAT_NAMESPACE NPat2H
++
++#define __AUTO_REMOVE
++#define __NODE_2_BITS
++#define __HASH_3
++
++#include "Pat.h"
++#include "PatMain.h"
++
++#undef __AUTO_REMOVE
++#undef __NODE_2_BITS
++#undef __HASH_3
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
+new file mode 100644
+index 0000000..d2d291c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
+@@ -0,0 +1,20 @@
++// Pat2R.h
++
++#ifndef __PAT2R__H
++#define __PAT2R__H
++
++#undef PAT_CLSID
++#define PAT_CLSID CLSID_CMatchFinderPat2R
++
++#undef PAT_NAMESPACE
++#define PAT_NAMESPACE NPat2R
++
++#define __NODE_2_BITS
++
++#include "Pat.h"
++#include "PatMain.h"
++
++#undef  __NODE_2_BITS
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
+new file mode 100644
+index 0000000..0f1d6aa
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
+@@ -0,0 +1,24 @@
++// Pat3H.h
++
++#ifndef __PAT3H__H
++#define __PAT3H__H
++
++#undef PAT_CLSID
++#define PAT_CLSID CLSID_CMatchFinderPat3H
++
++#undef PAT_NAMESPACE
++#define PAT_NAMESPACE NPat3H
++
++#define __AUTO_REMOVE
++#define __NODE_3_BITS
++#define __HASH_3
++
++#include "Pat.h"
++#include "PatMain.h"
++
++#undef __AUTO_REMOVE
++#undef __NODE_3_BITS
++#undef __HASH_3
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
+new file mode 100644
+index 0000000..9d8dc79
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
+@@ -0,0 +1,24 @@
++// Pat4H.h
++
++#ifndef __PAT4H__H
++#define __PAT4H__H
++
++#undef PAT_CLSID
++#define PAT_CLSID CLSID_CMatchFinderPat4H
++
++#undef PAT_NAMESPACE
++#define PAT_NAMESPACE NPat4H
++
++#define __AUTO_REMOVE
++#define __NODE_4_BITS
++#define __HASH_3
++
++#include "Pat.h"
++#include "PatMain.h"
++
++#undef __AUTO_REMOVE
++#undef __NODE_4_BITS
++#undef __HASH_3
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
+new file mode 100644
+index 0000000..0d06f14
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
 @@ -0,0 +1,989 @@
 +// PatMain.h
 +
@@ -22062,9 +21871,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
+new file mode 100644
+index 0000000..3ff6d8a
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -22072,9 +21883,99 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define __STDAFX_H
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
+new file mode 100644
+index 0000000..7bc4c43
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
+@@ -0,0 +1,82 @@
++// LZMA.h
++
++#ifndef __LZMA_H
++#define __LZMA_H
++
++namespace NCompress {
++namespace NLZMA {
++
++const UInt32 kNumRepDistances = 4;
++
++const int kNumStates = 12;
++
++const Byte kLiteralNextStates[kNumStates] = {0, 0, 0, 0, 1, 2, 3, 4,  5,  6,   4, 5};
++const Byte kMatchNextStates[kNumStates]   = {7, 7, 7, 7, 7, 7, 7, 10, 10, 10, 10, 10};
++const Byte kRepNextStates[kNumStates]     = {8, 8, 8, 8, 8, 8, 8, 11, 11, 11, 11, 11};
++const Byte kShortRepNextStates[kNumStates]= {9, 9, 9, 9, 9, 9, 9, 11, 11, 11, 11, 11};
++
++class CState
++{
++public:
++  Byte Index;
++  void Init() { Index = 0; }
++  void UpdateChar() { Index = kLiteralNextStates[Index]; }
++  void UpdateMatch() { Index = kMatchNextStates[Index]; }
++  void UpdateRep() { Index = kRepNextStates[Index]; }
++  void UpdateShortRep() { Index = kShortRepNextStates[Index]; }
++  bool IsCharState() const { return Index < 7; }
++};
++
++const int kNumPosSlotBits = 6; 
++const int kDicLogSizeMin = 0; 
++const int kDicLogSizeMax = 32; 
++const int kDistTableSizeMax = kDicLogSizeMax * 2; 
++
++const UInt32 kNumLenToPosStates = 4;
++
++inline UInt32 GetLenToPosState(UInt32 len)
++{
++  len -= 2;
++  if (len < kNumLenToPosStates)
++    return len;
++  return kNumLenToPosStates - 1;
++}
++
++namespace NLength {
++
++const int kNumPosStatesBitsMax = 4;
++const UInt32 kNumPosStatesMax = (1 << kNumPosStatesBitsMax);
++
++const int kNumPosStatesBitsEncodingMax = 4;
++const UInt32 kNumPosStatesEncodingMax = (1 << kNumPosStatesBitsEncodingMax);
++
++const int kNumLowBits = 3;
++const int kNumMidBits = 3;
++const int kNumHighBits = 8;
++const UInt32 kNumLowSymbols = 1 << kNumLowBits;
++const UInt32 kNumMidSymbols = 1 << kNumMidBits;
++const UInt32 kNumSymbolsTotal = kNumLowSymbols + kNumMidSymbols + (1 << kNumHighBits);
++
++}
++
++const UInt32 kMatchMinLen = 2;
++const UInt32 kMatchMaxLen = kMatchMinLen + NLength::kNumSymbolsTotal - 1;
++
++const int kNumAlignBits = 4;
++const UInt32 kAlignTableSize = 1 << kNumAlignBits;
++const UInt32 kAlignMask = (kAlignTableSize - 1);
++
++const UInt32 kStartPosModelIndex = 4;
++const UInt32 kEndPosModelIndex = 14;
++const UInt32 kNumPosModels = kEndPosModelIndex - kStartPosModelIndex;
++
++const UInt32 kNumFullDistances = 1 << (kEndPosModelIndex / 2);
++
++const int kNumLitPosStatesBitsEncodingMax = 4;
++const int kNumLitContextBitsMax = 8;
++
++const int kNumMoveBits = 5;
++
++}}
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
+new file mode 100644
+index 0000000..7f6a4a3
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
 @@ -0,0 +1,342 @@
 +// LZMADecoder.cpp
 +
@@ -22418,9 +22319,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
+new file mode 100644
+index 0000000..ee92f55
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
 @@ -0,0 +1,249 @@
 +// LZMA/Decoder.h
 +
@@ -22671,9 +22574,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
+new file mode 100644
+index 0000000..d3cb55d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
 @@ -0,0 +1,1504 @@
 +// LZMA/Encoder.cpp
 +
@@ -24179,9 +24084,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 +}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
+new file mode 100644
+index 0000000..4c5f5c1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
 @@ -0,0 +1,416 @@
 +// LZMA/Encoder.h
 +
@@ -24599,95 +24506,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,82 @@
-+// LZMA.h
-+
-+#ifndef __LZMA_H
-+#define __LZMA_H
-+
-+namespace NCompress {
-+namespace NLZMA {
-+
-+const UInt32 kNumRepDistances = 4;
-+
-+const int kNumStates = 12;
-+
-+const Byte kLiteralNextStates[kNumStates] = {0, 0, 0, 0, 1, 2, 3, 4,  5,  6,   4, 5};
-+const Byte kMatchNextStates[kNumStates]   = {7, 7, 7, 7, 7, 7, 7, 10, 10, 10, 10, 10};
-+const Byte kRepNextStates[kNumStates]     = {8, 8, 8, 8, 8, 8, 8, 11, 11, 11, 11, 11};
-+const Byte kShortRepNextStates[kNumStates]= {9, 9, 9, 9, 9, 9, 9, 11, 11, 11, 11, 11};
-+
-+class CState
-+{
-+public:
-+  Byte Index;
-+  void Init() { Index = 0; }
-+  void UpdateChar() { Index = kLiteralNextStates[Index]; }
-+  void UpdateMatch() { Index = kMatchNextStates[Index]; }
-+  void UpdateRep() { Index = kRepNextStates[Index]; }
-+  void UpdateShortRep() { Index = kShortRepNextStates[Index]; }
-+  bool IsCharState() const { return Index < 7; }
-+};
-+
-+const int kNumPosSlotBits = 6; 
-+const int kDicLogSizeMin = 0; 
-+const int kDicLogSizeMax = 32; 
-+const int kDistTableSizeMax = kDicLogSizeMax * 2; 
-+
-+const UInt32 kNumLenToPosStates = 4;
-+
-+inline UInt32 GetLenToPosState(UInt32 len)
-+{
-+  len -= 2;
-+  if (len < kNumLenToPosStates)
-+    return len;
-+  return kNumLenToPosStates - 1;
-+}
-+
-+namespace NLength {
-+
-+const int kNumPosStatesBitsMax = 4;
-+const UInt32 kNumPosStatesMax = (1 << kNumPosStatesBitsMax);
-+
-+const int kNumPosStatesBitsEncodingMax = 4;
-+const UInt32 kNumPosStatesEncodingMax = (1 << kNumPosStatesBitsEncodingMax);
-+
-+const int kNumLowBits = 3;
-+const int kNumMidBits = 3;
-+const int kNumHighBits = 8;
-+const UInt32 kNumLowSymbols = 1 << kNumLowBits;
-+const UInt32 kNumMidSymbols = 1 << kNumMidBits;
-+const UInt32 kNumSymbolsTotal = kNumLowSymbols + kNumMidSymbols + (1 << kNumHighBits);
-+
-+}
-+
-+const UInt32 kMatchMinLen = 2;
-+const UInt32 kMatchMaxLen = kMatchMinLen + NLength::kNumSymbolsTotal - 1;
-+
-+const int kNumAlignBits = 4;
-+const UInt32 kAlignTableSize = 1 << kNumAlignBits;
-+const UInt32 kAlignMask = (kAlignTableSize - 1);
-+
-+const UInt32 kStartPosModelIndex = 4;
-+const UInt32 kEndPosModelIndex = 14;
-+const UInt32 kNumPosModels = kEndPosModelIndex - kStartPosModelIndex;
-+
-+const UInt32 kNumFullDistances = 1 << (kEndPosModelIndex / 2);
-+
-+const int kNumLitPosStatesBitsEncodingMax = 4;
-+const int kNumLitContextBitsMax = 8;
-+
-+const int kNumMoveBits = 5;
-+
-+}}
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
+new file mode 100644
+index 0000000..e7fb698
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -24697,9 +24520,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
+new file mode 100644
+index 0000000..f9f3eb6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
 @@ -0,0 +1,523 @@
 +# Microsoft Developer Studio Project File - Name="AloneLZMA" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -25224,9 +25049,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +# End Source File
 +# End Target
 +# End Project
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
+new file mode 100644
+index 0000000..d7482d8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -25257,9 +25084,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +###############################################################################
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
+new file mode 100644
+index 0000000..e5a1914
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
 @@ -0,0 +1,509 @@
 +// LzmaAlone.cpp
 +
@@ -25770,9 +25599,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    return 1; 
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
+new file mode 100644
+index 0000000..21e2784
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
 @@ -0,0 +1,508 @@
 +// LzmaBench.cpp
 +
@@ -26282,9 +26113,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  fprintf(f, "    Average\n");
 +  return 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
+new file mode 100644
+index 0000000..bf1d3e0
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
 @@ -0,0 +1,11 @@
 +// LzmaBench.h
 +
@@ -26297,9 +26130,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +int LzmaBenchmark(FILE *f, UInt32 numIterations, UInt32 dictionarySize, bool isBT4);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
+new file mode 100644
+index 0000000..090d73d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
 @@ -0,0 +1,228 @@
 +// LzmaRam.cpp
 +
@@ -26529,9 +26364,63 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  } catch(...) { return SZE_OUTOFMEMORY; }
 +  #endif
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
+new file mode 100644
+index 0000000..1244dc8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
+@@ -0,0 +1,46 @@
++// LzmaRam.h
++
++#ifndef __LzmaRam_h
++#define __LzmaRam_h
++
++#include <stdlib.h>
++#include "../../../Common/Types.h"
++
++/*
++LzmaRamEncode: BCJ + LZMA RAM->RAM compressing.
++It uses .lzma format, but it writes one additional byte to .lzma file:
++  0: - no filter
++  1: - x86(BCJ) filter.
++
++To provide best compression ratio dictionarySize mustbe >= inSize
++
++LzmaRamEncode allocates Data with MyAlloc/BigAlloc functions.
++RAM Requirements:
++  RamSize = dictionarySize * 9.5 + 6MB + FilterBlockSize 
++    FilterBlockSize = 0, if useFilter == false
++    FilterBlockSize = inSize, if useFilter == true
++
++  Return code:
++    0 - OK
++    1 - Unspecified Error
++    2 - Memory allocating error
++    3 - Output buffer OVERFLOW
++
++If you use SZ_FILTER_AUTO mode, then encoder will use 2 or 3 passes:
++  2 passes when FILTER_NO provides better compression.
++  3 passes when FILTER_YES provides better compression.
++*/
++
++enum ESzFilterMode 
++{
++  SZ_FILTER_NO,
++  SZ_FILTER_YES,
++  SZ_FILTER_AUTO
++};
++
++int LzmaRamEncode(
++    const Byte *inBuffer, size_t inSize, 
++    Byte *outBuffer, size_t outSize, size_t *outSizeProcessed, 
++    UInt32 dictionarySize, ESzFilterMode filterMode);
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
+new file mode 100644
+index 0000000..ed1784d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
 @@ -0,0 +1,79 @@
 +/* LzmaRamDecode.c */
 +
@@ -26612,9 +26501,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +  return 0;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
+new file mode 100644
+index 0000000..7e641c5
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
 @@ -0,0 +1,55 @@
 +/* LzmaRamDecode.h */
 +
@@ -26671,59 +26562,34 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    void (*freeFunc)(void *));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,46 @@
-+// LzmaRam.h
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
+new file mode 100644
+index 0000000..d0feea8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
+@@ -0,0 +1,3 @@
++// StdAfx.cpp
 +
-+#ifndef __LzmaRam_h
-+#define __LzmaRam_h
++#include "StdAfx.h"
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
+new file mode 100644
+index 0000000..e7fb698
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
+@@ -0,0 +1,8 @@
++// StdAfx.h
 +
-+#include <stdlib.h>
-+#include "../../../Common/Types.h"
++#ifndef __STDAFX_H
++#define __STDAFX_H
 +
-+/*
-+LzmaRamEncode: BCJ + LZMA RAM->RAM compressing.
-+It uses .lzma format, but it writes one additional byte to .lzma file:
-+  0: - no filter
-+  1: - x86(BCJ) filter.
-+
-+To provide best compression ratio dictionarySize mustbe >= inSize
-+
-+LzmaRamEncode allocates Data with MyAlloc/BigAlloc functions.
-+RAM Requirements:
-+  RamSize = dictionarySize * 9.5 + 6MB + FilterBlockSize 
-+    FilterBlockSize = 0, if useFilter == false
-+    FilterBlockSize = inSize, if useFilter == true
-+
-+  Return code:
-+    0 - OK
-+    1 - Unspecified Error
-+    2 - Memory allocating error
-+    3 - Output buffer OVERFLOW
-+
-+If you use SZ_FILTER_AUTO mode, then encoder will use 2 or 3 passes:
-+  2 passes when FILTER_NO provides better compression.
-+  3 passes when FILTER_YES provides better compression.
-+*/
-+
-+enum ESzFilterMode 
-+{
-+  SZ_FILTER_NO,
-+  SZ_FILTER_YES,
-+  SZ_FILTER_AUTO
-+};
-+
-+int LzmaRamEncode(
-+    const Byte *inBuffer, size_t inSize, 
-+    Byte *outBuffer, size_t outSize, size_t *outSizeProcessed, 
-+    UInt32 dictionarySize, ESzFilterMode filterMode);
++#include "../../../Common/MyWindows.h"
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
+new file mode 100644
+index 0000000..63a63ae
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
 @@ -0,0 +1,100 @@
 +PROG = lzma.exe
 +CFLAGS = $(CFLAGS) -I ../../../
@@ -26825,9 +26691,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL)
 +$O\FileIO.obj: ../../../Windows/FileIO.cpp
 +	$(COMPL)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
+new file mode 100644
+index 0000000..1e18074
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
 @@ -0,0 +1,113 @@
 +PROG = lzma
 +CXX = g++ -O2 -Wall
@@ -26942,28 +26810,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,3 @@
-+// StdAfx.cpp
-+
-+#include "StdAfx.h"
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,8 @@
-+// StdAfx.h
-+
-+#ifndef __STDAFX_H
-+#define __STDAFX_H
-+
-+#include "../../../Common/MyWindows.h"
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
+new file mode 100644
+index 0000000..21bf40b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
 @@ -0,0 +1,588 @@
 +/*
 +  LzmaDecode.c
@@ -27553,9 +27404,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  *outSizeProcessed = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
+new file mode 100644
+index 0000000..213062a
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
 @@ -0,0 +1,131 @@
 +/* 
 +  LzmaDecode.h
@@ -27688,9 +27541,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    unsigned char *outStream, SizeT outSize, SizeT *outSizeProcessed);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
+new file mode 100644
+index 0000000..3dbdb2f
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
 @@ -0,0 +1,716 @@
 +/*
 +  LzmaDecodeSize.c
@@ -28408,9 +28263,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  *outSizeProcessed = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
+new file mode 100644
+index 0000000..5ccd0be
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
 @@ -0,0 +1,521 @@
 +/*
 +  LzmaStateDecode.c
@@ -28933,9 +28790,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  (*outSizeProcessed) = nowPos;
 +  return LZMA_RESULT_OK;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
+new file mode 100644
+index 0000000..272a0eb
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
 @@ -0,0 +1,115 @@
 +/* 
 +  LzmaStateDecode.h
@@ -29052,9 +28911,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +    int finishDecoding);
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
+new file mode 100644
+index 0000000..5df4e43
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
 @@ -0,0 +1,195 @@
 +/* 
 +LzmaStateTest.c
@@ -29251,9 +29112,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
+new file mode 100644
+index 0000000..f95a753
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
 @@ -0,0 +1,342 @@
 +/* 
 +LzmaTest.c
@@ -29597,9 +29460,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  printf(rs);
 +  return res;
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
+new file mode 100644
+index 0000000..7d6a93b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
 @@ -0,0 +1,43 @@
 +PROG = lzmaDec.exe
 +
@@ -29644,9 +29509,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL)
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
+new file mode 100644
+index 0000000..9b9c1a3
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
 @@ -0,0 +1,23 @@
 +PROG = lzmadec
 +CXX = gcc 
@@ -29671,130 +29538,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,21 @@
-+#ifndef __LZMA_LIB_H__
-+#define __LZMA_LIB_H__
-+
-+#include <zlib.h>
-+
-+// CJH: For Gentoo zlib compatibility
-+#ifdef _Z_OF
-+#undef OF
-+#define OF _Z_OF
-+#endif
-+
-+/* CJH: Depreciated.
-+int lzmalib_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
-+int lzma7z_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
-+int lzmalinksys_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
-+*/
-+
-+int lzmawrt_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
-+int lzmaspec_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int lc, int lp, int pb, int dictionary_size, int offset));
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2016-08-25 09:06:03.223530354 -0400
-@@ -0,0 +1,92 @@
-+PROG = liblzmalib.a
-+CXX = g++ -O3 -Wall
-+AR = ar
-+RM = rm -f
-+CFLAGS = -c  -I ../../../
-+
-+OBJS = \
-+  ZLib.o \
-+  LZMADecoder.o \
-+  LZMAEncoder.o \
-+  LZInWindow.o \
-+  LZOutWindow.o \
-+  RangeCoderBit.o \
-+  InBuffer.o \
-+  OutBuffer.o \
-+  FileStreams.o \
-+  Alloc.o \
-+  C_FileIO.o \
-+  CommandLineParser.o \
-+  CRC.o \
-+  StreamUtils.o \
-+  String.o \
-+  StringConvert.o \
-+  StringToInt.o \
-+  Vector.o \
-+
-+
-+all: $(PROG)
-+
-+$(PROG): $(OBJS)
-+	$(AR) r $(PROG) $(OBJS)
-+
-+ZLib.o: ZLib.cpp
-+	$(CXX) $(CFLAGS) ZLib.cpp
-+
-+LZMADecoder.o: ../LZMA/LZMADecoder.cpp
-+	$(CXX) $(CFLAGS) ../LZMA/LZMADecoder.cpp
-+
-+LZMAEncoder.o: ../LZMA/LZMAEncoder.cpp
-+	$(CXX) $(CFLAGS) ../LZMA/LZMAEncoder.cpp
-+
-+LZInWindow.o: ../LZ/LZInWindow.cpp
-+	$(CXX) $(CFLAGS) ../LZ/LZInWindow.cpp
-+
-+LZOutWindow.o: ../LZ/LZOutWindow.cpp
-+	$(CXX) $(CFLAGS) ../LZ/LZOutWindow.cpp
-+
-+RangeCoderBit.o: ../RangeCoder/RangeCoderBit.cpp
-+	$(CXX) $(CFLAGS) ../RangeCoder/RangeCoderBit.cpp
-+
-+InBuffer.o: ../../Common/InBuffer.cpp
-+	$(CXX) $(CFLAGS) ../../Common/InBuffer.cpp
-+
-+OutBuffer.o: ../../Common/OutBuffer.cpp
-+	$(CXX) $(CFLAGS) ../../Common/OutBuffer.cpp
-+
-+StreamUtils.o: ../../Common/StreamUtils.cpp
-+	$(CXX) $(CFLAGS) ../../Common/StreamUtils.cpp
-+
-+FileStreams.o: ../../Common/FileStreams.cpp
-+	$(CXX) $(CFLAGS) ../../Common/FileStreams.cpp
-+
-+Alloc.o: ../../../Common/Alloc.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/Alloc.cpp
-+
-+C_FileIO.o: ../../../Common/C_FileIO.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/C_FileIO.cpp
-+
-+CommandLineParser.o: ../../../Common/CommandLineParser.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/CommandLineParser.cpp
-+
-+CRC.o: ../../../Common/CRC.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/CRC.cpp
-+
-+MyWindows.o: ../../../Common/MyWindows.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/MyWindows.cpp
-+
-+String.o: ../../../Common/String.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/String.cpp
-+
-+StringConvert.o: ../../../Common/StringConvert.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/StringConvert.cpp
-+
-+StringToInt.o: ../../../Common/StringToInt.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/StringToInt.cpp
-+
-+Vector.o: ../../../Common/Vector.cpp
-+	$(CXX) $(CFLAGS) ../../../Common/Vector.cpp
-+
-+clean:
-+	-$(RM) $(PROG) $(OBJS)
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2016-08-25 09:06:03.223530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
+new file mode 100644
+index 0000000..f5a93fe
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
 @@ -0,0 +1,451 @@
 +/*
 + * lzma zlib simplified wrapper
@@ -30247,382 +29995,136 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	return Z_OK;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,80 @@
-+// Compress/RangeCoder/RangeCoderBit.cpp
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
+new file mode 100644
+index 0000000..2b290f0
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
+@@ -0,0 +1,21 @@
++#ifndef __LZMA_LIB_H__
++#define __LZMA_LIB_H__
 +
-+#include "StdAfx.h"
++#include <zlib.h>
 +
-+#include "RangeCoderBit.h"
++// CJH: For Gentoo zlib compatibility
++#ifdef _Z_OF
++#undef OF
++#define OF _Z_OF
++#endif
 +
-+namespace NCompress {
-+namespace NRangeCoder {
++/* CJH: Depreciated.
++int lzmalib_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
++int lzma7z_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
++int lzmalinksys_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
++*/
 +
-+UInt32 CPriceTables::ProbPrices[kBitModelTotal >> kNumMoveReducingBits];
-+static CPriceTables g_PriceTables;
-+
-+CPriceTables::CPriceTables() { Init(); }
-+
-+void CPriceTables::Init()
-+{
-+  const int kNumBits = (kNumBitModelTotalBits - kNumMoveReducingBits);
-+  for(int i = kNumBits - 1; i >= 0; i--)
-+  {
-+    UInt32 start = 1 << (kNumBits - i - 1);
-+    UInt32 end = 1 << (kNumBits - i);
-+    for (UInt32 j = start; j < end; j++)
-+      ProbPrices[j] = (i << kNumBitPriceShiftBits) + 
-+          (((end - j) << kNumBitPriceShiftBits) >> (kNumBits - i - 1));
-+  }
-+
-+  /*
-+  // simplest: bad solution
-+  for(UInt32 i = 1; i < (kBitModelTotal >> kNumMoveReducingBits) - 1; i++)
-+    ProbPrices[i] = kBitPrice;
-+  */
-+  
-+  /*
-+  const double kDummyMultMid = (1.0 / kBitPrice) / 2;
-+  const double kDummyMultMid = 0;
-+  // float solution
-+  double ln2 = log(double(2));
-+  double lnAll = log(double(kBitModelTotal >> kNumMoveReducingBits));
-+  for(UInt32 i = 1; i < (kBitModelTotal >> kNumMoveReducingBits) - 1; i++)
-+    ProbPrices[i] = UInt32((fabs(lnAll - log(double(i))) / ln2 + kDummyMultMid) * kBitPrice);
-+  */
-+  
-+  /*
-+  // experimental, slow, solution:
-+  for(UInt32 i = 1; i < (kBitModelTotal >> kNumMoveReducingBits) - 1; i++)
-+  {
-+    const int kCyclesBits = 5;
-+    const UInt32 kCycles = (1 << kCyclesBits);
-+
-+    UInt32 range = UInt32(-1);
-+    UInt32 bitCount = 0;
-+    for (UInt32 j = 0; j < kCycles; j++)
-+    {
-+      range >>= (kNumBitModelTotalBits - kNumMoveReducingBits);
-+      range *= i;
-+      while(range < (1 << 31))
-+      {
-+        range <<= 1;
-+        bitCount++;
-+      }
-+    }
-+    bitCount <<= kNumBitPriceShiftBits;
-+    range -= (1 << 31);
-+    for (int k = kNumBitPriceShiftBits - 1; k >= 0; k--)
-+    {
-+      range <<= 1;
-+      if (range > (1 << 31))
-+      {
-+        bitCount += (1 << k);
-+        range -= (1 << 31);
-+      }
-+    }
-+    ProbPrices[i] = (bitCount 
-+      // + (1 << (kCyclesBits - 1))
-+      ) >> kCyclesBits;
-+  }
-+  */
-+}
-+
-+}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,120 @@
-+// Compress/RangeCoder/RangeCoderBit.h
-+
-+#ifndef __COMPRESS_RANGECODER_BIT_H
-+#define __COMPRESS_RANGECODER_BIT_H
-+
-+#include "RangeCoder.h"
-+
-+namespace NCompress {
-+namespace NRangeCoder {
-+
-+const int kNumBitModelTotalBits  = 11;
-+const UInt32 kBitModelTotal = (1 << kNumBitModelTotalBits);
-+
-+const int kNumMoveReducingBits = 2;
-+
-+const int kNumBitPriceShiftBits = 6;
-+const UInt32 kBitPrice = 1 << kNumBitPriceShiftBits;
-+
-+class CPriceTables
-+{
-+public:
-+  static UInt32 ProbPrices[kBitModelTotal >> kNumMoveReducingBits];
-+  static void Init();
-+  CPriceTables();
-+};
-+
-+template <int numMoveBits>
-+class CBitModel
-+{
-+public:
-+  UInt32 Prob;
-+  void UpdateModel(UInt32 symbol)
-+  {
-+    /*
-+    Prob -= (Prob + ((symbol - 1) & ((1 << numMoveBits) - 1))) >> numMoveBits;
-+    Prob += (1 - symbol) << (kNumBitModelTotalBits - numMoveBits);
-+    */
-+    if (symbol == 0)
-+      Prob += (kBitModelTotal - Prob) >> numMoveBits;
-+    else
-+      Prob -= (Prob) >> numMoveBits;
-+  }
-+public:
-+  void Init() { Prob = kBitModelTotal / 2; }
-+};
-+
-+template <int numMoveBits>
-+class CBitEncoder: public CBitModel<numMoveBits>
-+{
-+public:
-+  void Encode(CEncoder *encoder, UInt32 symbol)
-+  {
-+    /*
-+    encoder->EncodeBit(this->Prob, kNumBitModelTotalBits, symbol);
-+    this->UpdateModel(symbol);
-+    */
-+    UInt32 newBound = (encoder->Range >> kNumBitModelTotalBits) * this->Prob;
-+    if (symbol == 0)
-+    {
-+      encoder->Range = newBound;
-+      this->Prob += (kBitModelTotal - this->Prob) >> numMoveBits;
-+    }
-+    else
-+    {
-+      encoder->Low += newBound;
-+      encoder->Range -= newBound;
-+      this->Prob -= (this->Prob) >> numMoveBits;
-+    }
-+    if (encoder->Range < kTopValue)
-+    {
-+      encoder->Range <<= 8;
-+      encoder->ShiftLow();
-+    }
-+  }
-+  UInt32 GetPrice(UInt32 symbol) const
-+  {
-+    return CPriceTables::ProbPrices[
-+      (((this->Prob - symbol) ^ ((-(int)symbol))) & (kBitModelTotal - 1)) >> kNumMoveReducingBits];
-+  }
-+  UInt32 GetPrice0() const { return CPriceTables::ProbPrices[this->Prob >> kNumMoveReducingBits]; }
-+  UInt32 GetPrice1() const { return CPriceTables::ProbPrices[(kBitModelTotal - this->Prob) >> kNumMoveReducingBits]; }
-+};
-+
-+
-+template <int numMoveBits>
-+class CBitDecoder: public CBitModel<numMoveBits>
-+{
-+public:
-+  UInt32 Decode(CDecoder *decoder)
-+  {
-+    UInt32 newBound = (decoder->Range >> kNumBitModelTotalBits) * this->Prob;
-+    if (decoder->Code < newBound)
-+    {
-+      decoder->Range = newBound;
-+      this->Prob += (kBitModelTotal - this->Prob) >> numMoveBits;
-+      if (decoder->Range < kTopValue)
-+      {
-+        decoder->Code = (decoder->Code << 8) | decoder->Stream.ReadByte();
-+        decoder->Range <<= 8;
-+      }
-+      return 0;
-+    }
-+    else
-+    {
-+      decoder->Range -= newBound;
-+      decoder->Code -= newBound;
-+      this->Prob -= (this->Prob) >> numMoveBits;
-+      if (decoder->Range < kTopValue)
-+      {
-+        decoder->Code = (decoder->Code << 8) | decoder->Stream.ReadByte();
-+        decoder->Range <<= 8;
-+      }
-+      return 1;
-+    }
-+  }
-+};
-+
-+}}
++int lzmawrt_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen));
++int lzmaspec_uncompress OF((Bytef *dest, uLongf *destLen, const Bytef *source, uLong sourceLen, int lc, int lp, int pb, int dictionary_size, int offset));
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2016-08-25 09:06:03.227530354 -0400
-@@ -0,0 +1,161 @@
-+// Compress/RangeCoder/RangeCoderBitTree.h
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
+new file mode 100644
+index 0000000..9961b30
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
+@@ -0,0 +1,92 @@
++PROG = liblzmalib.a
++CXX = g++ -O3 -Wall
++AR = ar
++RM = rm -f
++CFLAGS = -c  -I ../../../
 +
-+#ifndef __COMPRESS_RANGECODER_BIT_TREE_H
-+#define __COMPRESS_RANGECODER_BIT_TREE_H
++OBJS = \
++  ZLib.o \
++  LZMADecoder.o \
++  LZMAEncoder.o \
++  LZInWindow.o \
++  LZOutWindow.o \
++  RangeCoderBit.o \
++  InBuffer.o \
++  OutBuffer.o \
++  FileStreams.o \
++  Alloc.o \
++  C_FileIO.o \
++  CommandLineParser.o \
++  CRC.o \
++  StreamUtils.o \
++  String.o \
++  StringConvert.o \
++  StringToInt.o \
++  Vector.o \
 +
-+#include "RangeCoderBit.h"
-+#include "RangeCoderOpt.h"
 +
-+namespace NCompress {
-+namespace NRangeCoder {
++all: $(PROG)
 +
-+template <int numMoveBits, int NumBitLevels>
-+class CBitTreeEncoder
-+{
-+  CBitEncoder<numMoveBits> Models[1 << NumBitLevels];
-+public:
-+  void Init()
-+  {
-+    for(UInt32 i = 1; i < (1 << NumBitLevels); i++)
-+      Models[i].Init();
-+  }
-+  void Encode(CEncoder *rangeEncoder, UInt32 symbol)
-+  {
-+    UInt32 modelIndex = 1;
-+    for (int bitIndex = NumBitLevels; bitIndex != 0 ;)
-+    {
-+      bitIndex--;
-+      UInt32 bit = (symbol >> bitIndex) & 1;
-+      Models[modelIndex].Encode(rangeEncoder, bit);
-+      modelIndex = (modelIndex << 1) | bit;
-+    }
-+  };
-+  void ReverseEncode(CEncoder *rangeEncoder, UInt32 symbol)
-+  {
-+    UInt32 modelIndex = 1;
-+    for (int i = 0; i < NumBitLevels; i++)
-+    {
-+      UInt32 bit = symbol & 1;
-+      Models[modelIndex].Encode(rangeEncoder, bit);
-+      modelIndex = (modelIndex << 1) | bit;
-+      symbol >>= 1;
-+    }
-+  }
-+  UInt32 GetPrice(UInt32 symbol) const
-+  {
-+    symbol |= (1 << NumBitLevels);
-+    UInt32 price = 0;
-+    while (symbol != 1)
-+    {
-+      price += Models[symbol >> 1].GetPrice(symbol & 1);
-+      symbol >>= 1;
-+    }
-+    return price;
-+  }
-+  UInt32 ReverseGetPrice(UInt32 symbol) const
-+  {
-+    UInt32 price = 0;
-+    UInt32 modelIndex = 1;
-+    for (int i = NumBitLevels; i != 0; i--)
-+    {
-+      UInt32 bit = symbol & 1;
-+      symbol >>= 1;
-+      price += Models[modelIndex].GetPrice(bit);
-+      modelIndex = (modelIndex << 1) | bit;
-+    }
-+    return price;
-+  }
-+};
++$(PROG): $(OBJS)
++	$(AR) r $(PROG) $(OBJS)
 +
-+template <int numMoveBits, int NumBitLevels>
-+class CBitTreeDecoder
-+{
-+  CBitDecoder<numMoveBits> Models[1 << NumBitLevels];
-+public:
-+  void Init()
-+  {
-+    for(UInt32 i = 1; i < (1 << NumBitLevels); i++)
-+      Models[i].Init();
-+  }
-+  UInt32 Decode(CDecoder *rangeDecoder)
-+  {
-+    UInt32 modelIndex = 1;
-+    RC_INIT_VAR
-+    for(int bitIndex = NumBitLevels; bitIndex != 0; bitIndex--)
-+    {
-+      // modelIndex = (modelIndex << 1) + Models[modelIndex].Decode(rangeDecoder);
-+      RC_GETBIT(numMoveBits, Models[modelIndex].Prob, modelIndex)
-+    }
-+    RC_FLUSH_VAR
-+    return modelIndex - (1 << NumBitLevels);
-+  };
-+  UInt32 ReverseDecode(CDecoder *rangeDecoder)
-+  {
-+    UInt32 modelIndex = 1;
-+    UInt32 symbol = 0;
-+    RC_INIT_VAR
-+    for(int bitIndex = 0; bitIndex < NumBitLevels; bitIndex++)
-+    {
-+      // UInt32 bit = Models[modelIndex].Decode(rangeDecoder);
-+      // modelIndex <<= 1;
-+      // modelIndex += bit;
-+      // symbol |= (bit << bitIndex);
-+      RC_GETBIT2(numMoveBits, Models[modelIndex].Prob, modelIndex, ; , symbol |= (1 << bitIndex))
-+    }
-+    RC_FLUSH_VAR
-+    return symbol;
-+  }
-+};
++ZLib.o: ZLib.cpp
++	$(CXX) $(CFLAGS) ZLib.cpp
 +
-+template <int numMoveBits>
-+void ReverseBitTreeEncode(CBitEncoder<numMoveBits> *Models, 
-+    CEncoder *rangeEncoder, int NumBitLevels, UInt32 symbol)
-+{
-+  UInt32 modelIndex = 1;
-+  for (int i = 0; i < NumBitLevels; i++)
-+  {
-+    UInt32 bit = symbol & 1;
-+    Models[modelIndex].Encode(rangeEncoder, bit);
-+    modelIndex = (modelIndex << 1) | bit;
-+    symbol >>= 1;
-+  }
-+}
++LZMADecoder.o: ../LZMA/LZMADecoder.cpp
++	$(CXX) $(CFLAGS) ../LZMA/LZMADecoder.cpp
 +
-+template <int numMoveBits>
-+UInt32 ReverseBitTreeGetPrice(CBitEncoder<numMoveBits> *Models, 
-+    UInt32 NumBitLevels, UInt32 symbol)
-+{
-+  UInt32 price = 0;
-+  UInt32 modelIndex = 1;
-+  for (int i = NumBitLevels; i != 0; i--)
-+  {
-+    UInt32 bit = symbol & 1;
-+    symbol >>= 1;
-+    price += Models[modelIndex].GetPrice(bit);
-+    modelIndex = (modelIndex << 1) | bit;
-+  }
-+  return price;
-+}
++LZMAEncoder.o: ../LZMA/LZMAEncoder.cpp
++	$(CXX) $(CFLAGS) ../LZMA/LZMAEncoder.cpp
 +
-+template <int numMoveBits>
-+UInt32 ReverseBitTreeDecode(CBitDecoder<numMoveBits> *Models, 
-+    CDecoder *rangeDecoder, int NumBitLevels)
-+{
-+  UInt32 modelIndex = 1;
-+  UInt32 symbol = 0;
-+  RC_INIT_VAR
-+  for(int bitIndex = 0; bitIndex < NumBitLevels; bitIndex++)
-+  {
-+    // UInt32 bit = Models[modelIndex].Decode(rangeDecoder);
-+    // modelIndex <<= 1;
-+    // modelIndex += bit;
-+    // symbol |= (bit << bitIndex);
-+    RC_GETBIT2(numMoveBits, Models[modelIndex].Prob, modelIndex, ; , symbol |= (1 << bitIndex))
-+  }
-+  RC_FLUSH_VAR
-+  return symbol;
-+}
++LZInWindow.o: ../LZ/LZInWindow.cpp
++	$(CXX) $(CFLAGS) ../LZ/LZInWindow.cpp
 +
-+}}
++LZOutWindow.o: ../LZ/LZOutWindow.cpp
++	$(CXX) $(CFLAGS) ../LZ/LZOutWindow.cpp
 +
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2016-08-25 09:06:03.227530354 -0400
++RangeCoderBit.o: ../RangeCoder/RangeCoderBit.cpp
++	$(CXX) $(CFLAGS) ../RangeCoder/RangeCoderBit.cpp
++
++InBuffer.o: ../../Common/InBuffer.cpp
++	$(CXX) $(CFLAGS) ../../Common/InBuffer.cpp
++
++OutBuffer.o: ../../Common/OutBuffer.cpp
++	$(CXX) $(CFLAGS) ../../Common/OutBuffer.cpp
++
++StreamUtils.o: ../../Common/StreamUtils.cpp
++	$(CXX) $(CFLAGS) ../../Common/StreamUtils.cpp
++
++FileStreams.o: ../../Common/FileStreams.cpp
++	$(CXX) $(CFLAGS) ../../Common/FileStreams.cpp
++
++Alloc.o: ../../../Common/Alloc.cpp
++	$(CXX) $(CFLAGS) ../../../Common/Alloc.cpp
++
++C_FileIO.o: ../../../Common/C_FileIO.cpp
++	$(CXX) $(CFLAGS) ../../../Common/C_FileIO.cpp
++
++CommandLineParser.o: ../../../Common/CommandLineParser.cpp
++	$(CXX) $(CFLAGS) ../../../Common/CommandLineParser.cpp
++
++CRC.o: ../../../Common/CRC.cpp
++	$(CXX) $(CFLAGS) ../../../Common/CRC.cpp
++
++MyWindows.o: ../../../Common/MyWindows.cpp
++	$(CXX) $(CFLAGS) ../../../Common/MyWindows.cpp
++
++String.o: ../../../Common/String.cpp
++	$(CXX) $(CFLAGS) ../../../Common/String.cpp
++
++StringConvert.o: ../../../Common/StringConvert.cpp
++	$(CXX) $(CFLAGS) ../../../Common/StringConvert.cpp
++
++StringToInt.o: ../../../Common/StringToInt.cpp
++	$(CXX) $(CFLAGS) ../../../Common/StringToInt.cpp
++
++Vector.o: ../../../Common/Vector.cpp
++	$(CXX) $(CFLAGS) ../../../Common/Vector.cpp
++
++clean:
++	-$(RM) $(PROG) $(OBJS)
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
+new file mode 100644
+index 0000000..bbb2ba8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
 @@ -0,0 +1,205 @@
 +// Compress/RangeCoder/RangeCoder.h
 +
@@ -30829,9 +30331,390 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
+new file mode 100644
+index 0000000..8e4c4d3
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
+@@ -0,0 +1,80 @@
++// Compress/RangeCoder/RangeCoderBit.cpp
++
++#include "StdAfx.h"
++
++#include "RangeCoderBit.h"
++
++namespace NCompress {
++namespace NRangeCoder {
++
++UInt32 CPriceTables::ProbPrices[kBitModelTotal >> kNumMoveReducingBits];
++static CPriceTables g_PriceTables;
++
++CPriceTables::CPriceTables() { Init(); }
++
++void CPriceTables::Init()
++{
++  const int kNumBits = (kNumBitModelTotalBits - kNumMoveReducingBits);
++  for(int i = kNumBits - 1; i >= 0; i--)
++  {
++    UInt32 start = 1 << (kNumBits - i - 1);
++    UInt32 end = 1 << (kNumBits - i);
++    for (UInt32 j = start; j < end; j++)
++      ProbPrices[j] = (i << kNumBitPriceShiftBits) + 
++          (((end - j) << kNumBitPriceShiftBits) >> (kNumBits - i - 1));
++  }
++
++  /*
++  // simplest: bad solution
++  for(UInt32 i = 1; i < (kBitModelTotal >> kNumMoveReducingBits) - 1; i++)
++    ProbPrices[i] = kBitPrice;
++  */
++  
++  /*
++  const double kDummyMultMid = (1.0 / kBitPrice) / 2;
++  const double kDummyMultMid = 0;
++  // float solution
++  double ln2 = log(double(2));
++  double lnAll = log(double(kBitModelTotal >> kNumMoveReducingBits));
++  for(UInt32 i = 1; i < (kBitModelTotal >> kNumMoveReducingBits) - 1; i++)
++    ProbPrices[i] = UInt32((fabs(lnAll - log(double(i))) / ln2 + kDummyMultMid) * kBitPrice);
++  */
++  
++  /*
++  // experimental, slow, solution:
++  for(UInt32 i = 1; i < (kBitModelTotal >> kNumMoveReducingBits) - 1; i++)
++  {
++    const int kCyclesBits = 5;
++    const UInt32 kCycles = (1 << kCyclesBits);
++
++    UInt32 range = UInt32(-1);
++    UInt32 bitCount = 0;
++    for (UInt32 j = 0; j < kCycles; j++)
++    {
++      range >>= (kNumBitModelTotalBits - kNumMoveReducingBits);
++      range *= i;
++      while(range < (1 << 31))
++      {
++        range <<= 1;
++        bitCount++;
++      }
++    }
++    bitCount <<= kNumBitPriceShiftBits;
++    range -= (1 << 31);
++    for (int k = kNumBitPriceShiftBits - 1; k >= 0; k--)
++    {
++      range <<= 1;
++      if (range > (1 << 31))
++      {
++        bitCount += (1 << k);
++        range -= (1 << 31);
++      }
++    }
++    ProbPrices[i] = (bitCount 
++      // + (1 << (kCyclesBits - 1))
++      ) >> kCyclesBits;
++  }
++  */
++}
++
++}}
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
+new file mode 100644
+index 0000000..624f887
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
+@@ -0,0 +1,120 @@
++// Compress/RangeCoder/RangeCoderBit.h
++
++#ifndef __COMPRESS_RANGECODER_BIT_H
++#define __COMPRESS_RANGECODER_BIT_H
++
++#include "RangeCoder.h"
++
++namespace NCompress {
++namespace NRangeCoder {
++
++const int kNumBitModelTotalBits  = 11;
++const UInt32 kBitModelTotal = (1 << kNumBitModelTotalBits);
++
++const int kNumMoveReducingBits = 2;
++
++const int kNumBitPriceShiftBits = 6;
++const UInt32 kBitPrice = 1 << kNumBitPriceShiftBits;
++
++class CPriceTables
++{
++public:
++  static UInt32 ProbPrices[kBitModelTotal >> kNumMoveReducingBits];
++  static void Init();
++  CPriceTables();
++};
++
++template <int numMoveBits>
++class CBitModel
++{
++public:
++  UInt32 Prob;
++  void UpdateModel(UInt32 symbol)
++  {
++    /*
++    Prob -= (Prob + ((symbol - 1) & ((1 << numMoveBits) - 1))) >> numMoveBits;
++    Prob += (1 - symbol) << (kNumBitModelTotalBits - numMoveBits);
++    */
++    if (symbol == 0)
++      Prob += (kBitModelTotal - Prob) >> numMoveBits;
++    else
++      Prob -= (Prob) >> numMoveBits;
++  }
++public:
++  void Init() { Prob = kBitModelTotal / 2; }
++};
++
++template <int numMoveBits>
++class CBitEncoder: public CBitModel<numMoveBits>
++{
++public:
++  void Encode(CEncoder *encoder, UInt32 symbol)
++  {
++    /*
++    encoder->EncodeBit(this->Prob, kNumBitModelTotalBits, symbol);
++    this->UpdateModel(symbol);
++    */
++    UInt32 newBound = (encoder->Range >> kNumBitModelTotalBits) * this->Prob;
++    if (symbol == 0)
++    {
++      encoder->Range = newBound;
++      this->Prob += (kBitModelTotal - this->Prob) >> numMoveBits;
++    }
++    else
++    {
++      encoder->Low += newBound;
++      encoder->Range -= newBound;
++      this->Prob -= (this->Prob) >> numMoveBits;
++    }
++    if (encoder->Range < kTopValue)
++    {
++      encoder->Range <<= 8;
++      encoder->ShiftLow();
++    }
++  }
++  UInt32 GetPrice(UInt32 symbol) const
++  {
++    return CPriceTables::ProbPrices[
++      (((this->Prob - symbol) ^ ((-(int)symbol))) & (kBitModelTotal - 1)) >> kNumMoveReducingBits];
++  }
++  UInt32 GetPrice0() const { return CPriceTables::ProbPrices[this->Prob >> kNumMoveReducingBits]; }
++  UInt32 GetPrice1() const { return CPriceTables::ProbPrices[(kBitModelTotal - this->Prob) >> kNumMoveReducingBits]; }
++};
++
++
++template <int numMoveBits>
++class CBitDecoder: public CBitModel<numMoveBits>
++{
++public:
++  UInt32 Decode(CDecoder *decoder)
++  {
++    UInt32 newBound = (decoder->Range >> kNumBitModelTotalBits) * this->Prob;
++    if (decoder->Code < newBound)
++    {
++      decoder->Range = newBound;
++      this->Prob += (kBitModelTotal - this->Prob) >> numMoveBits;
++      if (decoder->Range < kTopValue)
++      {
++        decoder->Code = (decoder->Code << 8) | decoder->Stream.ReadByte();
++        decoder->Range <<= 8;
++      }
++      return 0;
++    }
++    else
++    {
++      decoder->Range -= newBound;
++      decoder->Code -= newBound;
++      this->Prob -= (this->Prob) >> numMoveBits;
++      if (decoder->Range < kTopValue)
++      {
++        decoder->Code = (decoder->Code << 8) | decoder->Stream.ReadByte();
++        decoder->Range <<= 8;
++      }
++      return 1;
++    }
++  }
++};
++
++}}
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
+new file mode 100644
+index 0000000..4f0c78b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
+@@ -0,0 +1,161 @@
++// Compress/RangeCoder/RangeCoderBitTree.h
++
++#ifndef __COMPRESS_RANGECODER_BIT_TREE_H
++#define __COMPRESS_RANGECODER_BIT_TREE_H
++
++#include "RangeCoderBit.h"
++#include "RangeCoderOpt.h"
++
++namespace NCompress {
++namespace NRangeCoder {
++
++template <int numMoveBits, int NumBitLevels>
++class CBitTreeEncoder
++{
++  CBitEncoder<numMoveBits> Models[1 << NumBitLevels];
++public:
++  void Init()
++  {
++    for(UInt32 i = 1; i < (1 << NumBitLevels); i++)
++      Models[i].Init();
++  }
++  void Encode(CEncoder *rangeEncoder, UInt32 symbol)
++  {
++    UInt32 modelIndex = 1;
++    for (int bitIndex = NumBitLevels; bitIndex != 0 ;)
++    {
++      bitIndex--;
++      UInt32 bit = (symbol >> bitIndex) & 1;
++      Models[modelIndex].Encode(rangeEncoder, bit);
++      modelIndex = (modelIndex << 1) | bit;
++    }
++  };
++  void ReverseEncode(CEncoder *rangeEncoder, UInt32 symbol)
++  {
++    UInt32 modelIndex = 1;
++    for (int i = 0; i < NumBitLevels; i++)
++    {
++      UInt32 bit = symbol & 1;
++      Models[modelIndex].Encode(rangeEncoder, bit);
++      modelIndex = (modelIndex << 1) | bit;
++      symbol >>= 1;
++    }
++  }
++  UInt32 GetPrice(UInt32 symbol) const
++  {
++    symbol |= (1 << NumBitLevels);
++    UInt32 price = 0;
++    while (symbol != 1)
++    {
++      price += Models[symbol >> 1].GetPrice(symbol & 1);
++      symbol >>= 1;
++    }
++    return price;
++  }
++  UInt32 ReverseGetPrice(UInt32 symbol) const
++  {
++    UInt32 price = 0;
++    UInt32 modelIndex = 1;
++    for (int i = NumBitLevels; i != 0; i--)
++    {
++      UInt32 bit = symbol & 1;
++      symbol >>= 1;
++      price += Models[modelIndex].GetPrice(bit);
++      modelIndex = (modelIndex << 1) | bit;
++    }
++    return price;
++  }
++};
++
++template <int numMoveBits, int NumBitLevels>
++class CBitTreeDecoder
++{
++  CBitDecoder<numMoveBits> Models[1 << NumBitLevels];
++public:
++  void Init()
++  {
++    for(UInt32 i = 1; i < (1 << NumBitLevels); i++)
++      Models[i].Init();
++  }
++  UInt32 Decode(CDecoder *rangeDecoder)
++  {
++    UInt32 modelIndex = 1;
++    RC_INIT_VAR
++    for(int bitIndex = NumBitLevels; bitIndex != 0; bitIndex--)
++    {
++      // modelIndex = (modelIndex << 1) + Models[modelIndex].Decode(rangeDecoder);
++      RC_GETBIT(numMoveBits, Models[modelIndex].Prob, modelIndex)
++    }
++    RC_FLUSH_VAR
++    return modelIndex - (1 << NumBitLevels);
++  };
++  UInt32 ReverseDecode(CDecoder *rangeDecoder)
++  {
++    UInt32 modelIndex = 1;
++    UInt32 symbol = 0;
++    RC_INIT_VAR
++    for(int bitIndex = 0; bitIndex < NumBitLevels; bitIndex++)
++    {
++      // UInt32 bit = Models[modelIndex].Decode(rangeDecoder);
++      // modelIndex <<= 1;
++      // modelIndex += bit;
++      // symbol |= (bit << bitIndex);
++      RC_GETBIT2(numMoveBits, Models[modelIndex].Prob, modelIndex, ; , symbol |= (1 << bitIndex))
++    }
++    RC_FLUSH_VAR
++    return symbol;
++  }
++};
++
++template <int numMoveBits>
++void ReverseBitTreeEncode(CBitEncoder<numMoveBits> *Models, 
++    CEncoder *rangeEncoder, int NumBitLevels, UInt32 symbol)
++{
++  UInt32 modelIndex = 1;
++  for (int i = 0; i < NumBitLevels; i++)
++  {
++    UInt32 bit = symbol & 1;
++    Models[modelIndex].Encode(rangeEncoder, bit);
++    modelIndex = (modelIndex << 1) | bit;
++    symbol >>= 1;
++  }
++}
++
++template <int numMoveBits>
++UInt32 ReverseBitTreeGetPrice(CBitEncoder<numMoveBits> *Models, 
++    UInt32 NumBitLevels, UInt32 symbol)
++{
++  UInt32 price = 0;
++  UInt32 modelIndex = 1;
++  for (int i = NumBitLevels; i != 0; i--)
++  {
++    UInt32 bit = symbol & 1;
++    symbol >>= 1;
++    price += Models[modelIndex].GetPrice(bit);
++    modelIndex = (modelIndex << 1) | bit;
++  }
++  return price;
++}
++
++template <int numMoveBits>
++UInt32 ReverseBitTreeDecode(CBitDecoder<numMoveBits> *Models, 
++    CDecoder *rangeDecoder, int NumBitLevels)
++{
++  UInt32 modelIndex = 1;
++  UInt32 symbol = 0;
++  RC_INIT_VAR
++  for(int bitIndex = 0; bitIndex < NumBitLevels; bitIndex++)
++  {
++    // UInt32 bit = Models[modelIndex].Decode(rangeDecoder);
++    // modelIndex <<= 1;
++    // modelIndex += bit;
++    // symbol |= (bit << bitIndex);
++    RC_GETBIT2(numMoveBits, Models[modelIndex].Prob, modelIndex, ; , symbol |= (1 << bitIndex))
++  }
++  RC_FLUSH_VAR
++  return symbol;
++}
++
++}}
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
+new file mode 100644
+index 0000000..668b9a5
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
 @@ -0,0 +1,31 @@
 +// Compress/RangeCoder/RangeCoderOpt.h
 +
@@ -30864,9 +30747,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define RC_GETBIT(numMoveBits, prob, mi) RC_GETBIT2(numMoveBits, prob, mi, ; , ;)
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
+new file mode 100644
+index 0000000..b637fd4
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -30874,9 +30759,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#define __STDAFX_H
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2016-08-25 09:06:03.223530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h
+new file mode 100644
+index 0000000..8d556fd
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h
 @@ -0,0 +1,156 @@
 +// ICoder.h
 +
@@ -31034,9 +30921,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2016-08-25 09:06:03.227530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h b/squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h
+new file mode 100644
+index 0000000..bba21a3
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h
 @@ -0,0 +1,62 @@
 +// IStream.h
 +
@@ -31100,9 +30989,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.
 +};
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp
+new file mode 100644
+index 0000000..e2b8c3d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp
 @@ -0,0 +1,118 @@
 +// Common/Alloc.cpp
 +
@@ -31222,9 +31113,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h
+new file mode 100644
+index 0000000..d444f63
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h
 @@ -0,0 +1,29 @@
 +// Common/Alloc.h
 +
@@ -31255,9 +31148,120 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp
+new file mode 100644
+index 0000000..35e1a18
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp
+@@ -0,0 +1,61 @@
++// Common/CRC.cpp
++
++#include "StdAfx.h"
++
++#include "CRC.h"
++
++static const UInt32 kCRCPoly = 0xEDB88320;
++
++UInt32 CCRC::Table[256];
++
++void CCRC::InitTable()
++{
++  for (UInt32 i = 0; i < 256; i++)
++  {
++    UInt32 r = i;
++    for (int j = 0; j < 8; j++)
++      if (r & 1) 
++        r = (r >> 1) ^ kCRCPoly;
++      else     
++        r >>= 1;
++    CCRC::Table[i] = r;
++  }
++}
++
++class CCRCTableInit
++{
++public:
++  CCRCTableInit() { CCRC::InitTable(); }
++} g_CRCTableInit;
++
++void CCRC::UpdateByte(Byte b)
++{
++  _value = Table[((Byte)(_value)) ^ b] ^ (_value >> 8);
++}
++
++void CCRC::UpdateUInt16(UInt16 v)
++{
++  UpdateByte(Byte(v));
++  UpdateByte(Byte(v >> 8));
++}
++
++void CCRC::UpdateUInt32(UInt32 v)
++{
++  for (int i = 0; i < 4; i++)
++    UpdateByte((Byte)(v >> (8 * i)));
++}
++
++void CCRC::UpdateUInt64(UInt64 v)
++{
++  for (int i = 0; i < 8; i++)
++    UpdateByte((Byte)(v >> (8 * i)));
++}
++
++void CCRC::Update(const void *data, size_t size)
++{
++  UInt32 v = _value;
++  const Byte *p = (const Byte *)data;
++  for (; size > 0 ; size--, p++)
++    v = Table[((Byte)(v)) ^ *p] ^ (v >> 8);
++  _value = v;
++}
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h
+new file mode 100644
+index 0000000..6b4f1b7
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h
+@@ -0,0 +1,36 @@
++// Common/CRC.h
++
++#ifndef __COMMON_CRC_H
++#define __COMMON_CRC_H
++
++#include <stddef.h>
++#include "Types.h"
++
++class CCRC
++{
++  UInt32 _value;
++public:
++	static UInt32 Table[256];
++	static void InitTable();
++
++  CCRC():  _value(0xFFFFFFFF){};
++  void Init() { _value = 0xFFFFFFFF; }
++  void UpdateByte(Byte v);
++  void UpdateUInt16(UInt16 v);
++  void UpdateUInt32(UInt32 v);
++  void UpdateUInt64(UInt64 v);
++  void Update(const void *data, size_t size);
++  UInt32 GetDigest() const { return _value ^ 0xFFFFFFFF; } 
++  static UInt32 CalculateDigest(const void *data, size_t size)
++  {
++    CCRC crc;
++    crc.Update(data, size);
++    return crc.GetDigest();
++  }
++  static bool VerifyDigest(UInt32 digest, const void *data, size_t size)
++  {
++    return (CalculateDigest(data, size) == digest);
++  }
++};
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
+new file mode 100644
+index 0000000..7d9e00d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
 @@ -0,0 +1,78 @@
 +// Common/C_FileIO.h
 +
@@ -31337,9 +31341,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +}
 +
 +}}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h
+new file mode 100644
+index 0000000..2ad0716
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h
 @@ -0,0 +1,45 @@
 +// Common/C_FileIO.h
 +
@@ -31386,9 +31392,34 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +}}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h
+new file mode 100644
+index 0000000..5153362
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h
+@@ -0,0 +1,17 @@
++// ComTry.h
++
++#ifndef __COM_TRY_H
++#define __COM_TRY_H
++
++#include "MyWindows.h"
++// #include "Exception.h"
++// #include "NewHandler.h"
++
++#define COM_TRY_BEGIN try {
++#define COM_TRY_END } catch(...) { return E_OUTOFMEMORY; }
++  
++  // catch(const CNewException &) { return E_OUTOFMEMORY; }\
++  // catch(const CSystemException &e) { return e.ErrorCode; }\
++  // catch(...) { return E_FAIL; }
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
+new file mode 100644
+index 0000000..27a3d38
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
 @@ -0,0 +1,263 @@
 +// CommandLineParser.cpp
 +
@@ -31653,9 +31684,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +}
 +
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h
+new file mode 100644
+index 0000000..e1fe144
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h
 @@ -0,0 +1,82 @@
 +// Common/CommandLineParser.h
 +
@@ -31739,135 +31772,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,17 @@
-+// ComTry.h
-+
-+#ifndef __COM_TRY_H
-+#define __COM_TRY_H
-+
-+#include "MyWindows.h"
-+// #include "Exception.h"
-+// #include "NewHandler.h"
-+
-+#define COM_TRY_BEGIN try {
-+#define COM_TRY_END } catch(...) { return E_OUTOFMEMORY; }
-+  
-+  // catch(const CNewException &) { return E_OUTOFMEMORY; }\
-+  // catch(const CSystemException &e) { return e.ErrorCode; }\
-+  // catch(...) { return E_FAIL; }
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,61 @@
-+// Common/CRC.cpp
-+
-+#include "StdAfx.h"
-+
-+#include "CRC.h"
-+
-+static const UInt32 kCRCPoly = 0xEDB88320;
-+
-+UInt32 CCRC::Table[256];
-+
-+void CCRC::InitTable()
-+{
-+  for (UInt32 i = 0; i < 256; i++)
-+  {
-+    UInt32 r = i;
-+    for (int j = 0; j < 8; j++)
-+      if (r & 1) 
-+        r = (r >> 1) ^ kCRCPoly;
-+      else     
-+        r >>= 1;
-+    CCRC::Table[i] = r;
-+  }
-+}
-+
-+class CCRCTableInit
-+{
-+public:
-+  CCRCTableInit() { CCRC::InitTable(); }
-+} g_CRCTableInit;
-+
-+void CCRC::UpdateByte(Byte b)
-+{
-+  _value = Table[((Byte)(_value)) ^ b] ^ (_value >> 8);
-+}
-+
-+void CCRC::UpdateUInt16(UInt16 v)
-+{
-+  UpdateByte(Byte(v));
-+  UpdateByte(Byte(v >> 8));
-+}
-+
-+void CCRC::UpdateUInt32(UInt32 v)
-+{
-+  for (int i = 0; i < 4; i++)
-+    UpdateByte((Byte)(v >> (8 * i)));
-+}
-+
-+void CCRC::UpdateUInt64(UInt64 v)
-+{
-+  for (int i = 0; i < 8; i++)
-+    UpdateByte((Byte)(v >> (8 * i)));
-+}
-+
-+void CCRC::Update(const void *data, size_t size)
-+{
-+  UInt32 v = _value;
-+  const Byte *p = (const Byte *)data;
-+  for (; size > 0 ; size--, p++)
-+    v = Table[((Byte)(v)) ^ *p] ^ (v >> 8);
-+  _value = v;
-+}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,36 @@
-+// Common/CRC.h
-+
-+#ifndef __COMMON_CRC_H
-+#define __COMMON_CRC_H
-+
-+#include <stddef.h>
-+#include "Types.h"
-+
-+class CCRC
-+{
-+  UInt32 _value;
-+public:
-+	static UInt32 Table[256];
-+	static void InitTable();
-+
-+  CCRC():  _value(0xFFFFFFFF){};
-+  void Init() { _value = 0xFFFFFFFF; }
-+  void UpdateByte(Byte v);
-+  void UpdateUInt16(UInt16 v);
-+  void UpdateUInt32(UInt32 v);
-+  void UpdateUInt64(UInt64 v);
-+  void Update(const void *data, size_t size);
-+  UInt32 GetDigest() const { return _value ^ 0xFFFFFFFF; } 
-+  static UInt32 CalculateDigest(const void *data, size_t size)
-+  {
-+    CCRC crc;
-+    crc.Update(data, size);
-+    return crc.GetDigest();
-+  }
-+  static bool VerifyDigest(UInt32 digest, const void *data, size_t size)
-+  {
-+    return (CalculateDigest(data, size) == digest);
-+  }
-+};
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h
+new file mode 100644
+index 0000000..dad3ae8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h
 @@ -0,0 +1,20 @@
 +// Common/Defs.h
 +
@@ -31889,9 +31798,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h
 +  { return (value != 0); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h
+new file mode 100644
+index 0000000..e903493
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h
 @@ -0,0 +1,203 @@
 +// MyCom.h
 +
@@ -32096,9 +32007,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.
 +  )
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h
+new file mode 100644
+index 0000000..2c954f8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h
 @@ -0,0 +1,54 @@
 +// Common/MyGuidDef.h
 +
@@ -32154,9 +32067,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuid
 +  #define DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
 +    MY_EXTERN_C const GUID name
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h
+new file mode 100644
+index 0000000..5bdfeed
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h
 @@ -0,0 +1,13 @@
 +// Common/MyInitGuid.h
 +
@@ -32171,9 +32086,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInit
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h
+new file mode 100644
+index 0000000..d28d854
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h
 @@ -0,0 +1,24 @@
 +// MyUnknown.h
 +
@@ -32199,9 +32116,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnkn
 +#endif
 +  
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h
+new file mode 100644
+index 0000000..6df08d6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h
 @@ -0,0 +1,183 @@
 +// MyWindows.h
 +
@@ -32386,9 +32305,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWind
 +
 +#endif
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp
+new file mode 100644
+index 0000000..9994297
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp
 @@ -0,0 +1,114 @@
 +// NewHandler.cpp
 + 
@@ -32504,9 +32425,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +  // _set_new_handler(MemErrorOldVCFunction);
 +}
 +*/
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h
+new file mode 100644
+index 0000000..91ad34c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h
 @@ -0,0 +1,14 @@
 +// Common/NewHandler.h
 +
@@ -32522,9 +32445,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +operator delete(void *p) throw();
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h
+new file mode 100644
+index 0000000..681ee93
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -32535,181 +32460,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx
 +#include "NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,93 @@
-+// Common/StringConvert.cpp
-+
-+#include "StdAfx.h"
-+
-+#include "StringConvert.h"
-+
-+#ifndef _WIN32
-+#include <stdlib.h>
-+#endif
-+
-+#ifdef _WIN32
-+UString MultiByteToUnicodeString(const AString &srcString, UINT codePage)
-+{
-+  UString resultString;
-+  if(!srcString.IsEmpty())
-+  {
-+    int numChars = MultiByteToWideChar(codePage, 0, srcString, 
-+      srcString.Length(), resultString.GetBuffer(srcString.Length()), 
-+      srcString.Length() + 1);
-+    #ifndef _WIN32_WCE
-+    if(numChars == 0)
-+      throw 282228;
-+    #endif
-+    resultString.ReleaseBuffer(numChars);
-+  }
-+  return resultString;
-+}
-+
-+AString UnicodeStringToMultiByte(const UString &srcString, UINT codePage)
-+{
-+  AString resultString;
-+  if(!srcString.IsEmpty())
-+  {
-+    int numRequiredBytes = srcString.Length() * 2;
-+    int numChars = WideCharToMultiByte(codePage, 0, srcString, 
-+      srcString.Length(), resultString.GetBuffer(numRequiredBytes), 
-+      numRequiredBytes + 1, NULL, NULL);
-+    #ifndef _WIN32_WCE
-+    if(numChars == 0)
-+      throw 282229;
-+    #endif
-+    resultString.ReleaseBuffer(numChars);
-+  }
-+  return resultString;
-+}
-+
-+#ifndef _WIN32_WCE
-+AString SystemStringToOemString(const CSysString &srcString)
-+{
-+  AString result;
-+  CharToOem(srcString, result.GetBuffer(srcString.Length() * 2));
-+  result.ReleaseBuffer();
-+  return result;
-+}
-+#endif
-+
-+#else
-+
-+UString MultiByteToUnicodeString(const AString &srcString, UINT codePage)
-+{
-+  UString resultString;
-+  for (int i = 0; i < srcString.Length(); i++)
-+    resultString += wchar_t(srcString[i]);
-+  /*
-+  if(!srcString.IsEmpty())
-+  {
-+    int numChars = mbstowcs(resultString.GetBuffer(srcString.Length()), srcString, srcString.Length() + 1);
-+    if (numChars < 0) throw "Your environment does not support UNICODE";
-+    resultString.ReleaseBuffer(numChars);
-+  }
-+  */
-+  return resultString;
-+}
-+
-+AString UnicodeStringToMultiByte(const UString &srcString, UINT codePage)
-+{
-+  AString resultString;
-+  for (int i = 0; i < srcString.Length(); i++)
-+    resultString += char(srcString[i]);
-+  /*
-+  if(!srcString.IsEmpty())
-+  {
-+    int numRequiredBytes = srcString.Length() * 6 + 1;
-+    int numChars = wcstombs(resultString.GetBuffer(numRequiredBytes), srcString, numRequiredBytes);
-+    if (numChars < 0) throw "Your environment does not support UNICODE";
-+    resultString.ReleaseBuffer(numChars);
-+  }
-+  */
-+  return resultString;
-+}
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,71 @@
-+// Common/StringConvert.h
-+
-+#ifndef __COMMON_STRINGCONVERT_H
-+#define __COMMON_STRINGCONVERT_H
-+
-+#include "MyWindows.h"
-+#include "Common/String.h"
-+#include "Types.h"
-+
-+UString MultiByteToUnicodeString(const AString &srcString, UINT codePage = CP_ACP);
-+AString UnicodeStringToMultiByte(const UString &srcString, UINT codePage = CP_ACP);
-+
-+inline const wchar_t* GetUnicodeString(const wchar_t* unicodeString)
-+  { return unicodeString; }
-+inline const UString& GetUnicodeString(const UString &unicodeString)
-+  { return unicodeString; }
-+inline UString GetUnicodeString(const AString &ansiString)
-+  { return MultiByteToUnicodeString(ansiString); }
-+inline UString GetUnicodeString(const AString &multiByteString, UINT codePage)
-+  { return MultiByteToUnicodeString(multiByteString, codePage); }
-+inline const wchar_t* GetUnicodeString(const wchar_t* unicodeString, UINT)
-+  { return unicodeString; }
-+inline const UString& GetUnicodeString(const UString &unicodeString, UINT)
-+  { return unicodeString; }
-+
-+inline const char* GetAnsiString(const char* ansiString)
-+  { return ansiString; }
-+inline const AString& GetAnsiString(const AString &ansiString)
-+  { return ansiString; }
-+inline AString GetAnsiString(const UString &unicodeString)
-+  { return UnicodeStringToMultiByte(unicodeString); }
-+
-+inline const char* GetOemString(const char* oemString)
-+  { return oemString; }
-+inline const AString& GetOemString(const AString &oemString)
-+  { return oemString; }
-+inline AString GetOemString(const UString &unicodeString)
-+  { return UnicodeStringToMultiByte(unicodeString, CP_OEMCP); }
-+
-+
-+#ifdef _UNICODE
-+  inline const wchar_t* GetSystemString(const wchar_t* unicodeString)
-+    { return unicodeString;}
-+  inline const UString& GetSystemString(const UString &unicodeString)
-+    { return unicodeString;}
-+  inline const wchar_t* GetSystemString(const wchar_t* unicodeString, UINT codePage)
-+    { return unicodeString;}
-+  inline const UString& GetSystemString(const UString &unicodeString, UINT codePage)
-+    { return unicodeString;}
-+  inline UString GetSystemString(const AString &multiByteString, UINT codePage)
-+    { return MultiByteToUnicodeString(multiByteString, codePage);}
-+  inline UString GetSystemString(const AString &multiByteString)
-+    { return MultiByteToUnicodeString(multiByteString);}
-+#else
-+  inline const char* GetSystemString(const char *ansiString)
-+    { return ansiString; }
-+  inline const AString& GetSystemString(const AString &multiByteString, UINT)
-+    { return multiByteString; }
-+  inline const char * GetSystemString(const char *multiByteString, UINT)
-+    { return multiByteString; }
-+  inline AString GetSystemString(const UString &unicodeString)
-+    { return UnicodeStringToMultiByte(unicodeString); }
-+  inline AString GetSystemString(const UString &unicodeString, UINT codePage)
-+    { return UnicodeStringToMultiByte(unicodeString, codePage); }
-+#endif
-+
-+#ifndef _WIN32_WCE
-+AString SystemStringToOemString(const CSysString &srcString);
-+#endif
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp
+new file mode 100644
+index 0000000..7921fe4
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp
 @@ -0,0 +1,198 @@
 +// Common/String.cpp
 +
@@ -32909,9 +32664,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +  return MyStringCompareNoCase(MultiByteToUnicodeString(s1), MultiByteToUnicodeString(s2));
 +}
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/String.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/String.h
+new file mode 100644
+index 0000000..c4277c1
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/String.h
 @@ -0,0 +1,631 @@
 +// Common/String.h
 +
@@ -33544,9 +33301,187 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +typedef CObjectVector<CSysString> CSysStringVector;
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp
+new file mode 100644
+index 0000000..d6d05d6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp
+@@ -0,0 +1,93 @@
++// Common/StringConvert.cpp
++
++#include "StdAfx.h"
++
++#include "StringConvert.h"
++
++#ifndef _WIN32
++#include <stdlib.h>
++#endif
++
++#ifdef _WIN32
++UString MultiByteToUnicodeString(const AString &srcString, UINT codePage)
++{
++  UString resultString;
++  if(!srcString.IsEmpty())
++  {
++    int numChars = MultiByteToWideChar(codePage, 0, srcString, 
++      srcString.Length(), resultString.GetBuffer(srcString.Length()), 
++      srcString.Length() + 1);
++    #ifndef _WIN32_WCE
++    if(numChars == 0)
++      throw 282228;
++    #endif
++    resultString.ReleaseBuffer(numChars);
++  }
++  return resultString;
++}
++
++AString UnicodeStringToMultiByte(const UString &srcString, UINT codePage)
++{
++  AString resultString;
++  if(!srcString.IsEmpty())
++  {
++    int numRequiredBytes = srcString.Length() * 2;
++    int numChars = WideCharToMultiByte(codePage, 0, srcString, 
++      srcString.Length(), resultString.GetBuffer(numRequiredBytes), 
++      numRequiredBytes + 1, NULL, NULL);
++    #ifndef _WIN32_WCE
++    if(numChars == 0)
++      throw 282229;
++    #endif
++    resultString.ReleaseBuffer(numChars);
++  }
++  return resultString;
++}
++
++#ifndef _WIN32_WCE
++AString SystemStringToOemString(const CSysString &srcString)
++{
++  AString result;
++  CharToOem(srcString, result.GetBuffer(srcString.Length() * 2));
++  result.ReleaseBuffer();
++  return result;
++}
++#endif
++
++#else
++
++UString MultiByteToUnicodeString(const AString &srcString, UINT codePage)
++{
++  UString resultString;
++  for (int i = 0; i < srcString.Length(); i++)
++    resultString += wchar_t(srcString[i]);
++  /*
++  if(!srcString.IsEmpty())
++  {
++    int numChars = mbstowcs(resultString.GetBuffer(srcString.Length()), srcString, srcString.Length() + 1);
++    if (numChars < 0) throw "Your environment does not support UNICODE";
++    resultString.ReleaseBuffer(numChars);
++  }
++  */
++  return resultString;
++}
++
++AString UnicodeStringToMultiByte(const UString &srcString, UINT codePage)
++{
++  AString resultString;
++  for (int i = 0; i < srcString.Length(); i++)
++    resultString += char(srcString[i]);
++  /*
++  if(!srcString.IsEmpty())
++  {
++    int numRequiredBytes = srcString.Length() * 6 + 1;
++    int numChars = wcstombs(resultString.GetBuffer(numRequiredBytes), srcString, numRequiredBytes);
++    if (numChars < 0) throw "Your environment does not support UNICODE";
++    resultString.ReleaseBuffer(numChars);
++  }
++  */
++  return resultString;
++}
++
++#endif
++
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h
+new file mode 100644
+index 0000000..648ca02
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h
+@@ -0,0 +1,71 @@
++// Common/StringConvert.h
++
++#ifndef __COMMON_STRINGCONVERT_H
++#define __COMMON_STRINGCONVERT_H
++
++#include "MyWindows.h"
++#include "Common/String.h"
++#include "Types.h"
++
++UString MultiByteToUnicodeString(const AString &srcString, UINT codePage = CP_ACP);
++AString UnicodeStringToMultiByte(const UString &srcString, UINT codePage = CP_ACP);
++
++inline const wchar_t* GetUnicodeString(const wchar_t* unicodeString)
++  { return unicodeString; }
++inline const UString& GetUnicodeString(const UString &unicodeString)
++  { return unicodeString; }
++inline UString GetUnicodeString(const AString &ansiString)
++  { return MultiByteToUnicodeString(ansiString); }
++inline UString GetUnicodeString(const AString &multiByteString, UINT codePage)
++  { return MultiByteToUnicodeString(multiByteString, codePage); }
++inline const wchar_t* GetUnicodeString(const wchar_t* unicodeString, UINT)
++  { return unicodeString; }
++inline const UString& GetUnicodeString(const UString &unicodeString, UINT)
++  { return unicodeString; }
++
++inline const char* GetAnsiString(const char* ansiString)
++  { return ansiString; }
++inline const AString& GetAnsiString(const AString &ansiString)
++  { return ansiString; }
++inline AString GetAnsiString(const UString &unicodeString)
++  { return UnicodeStringToMultiByte(unicodeString); }
++
++inline const char* GetOemString(const char* oemString)
++  { return oemString; }
++inline const AString& GetOemString(const AString &oemString)
++  { return oemString; }
++inline AString GetOemString(const UString &unicodeString)
++  { return UnicodeStringToMultiByte(unicodeString, CP_OEMCP); }
++
++
++#ifdef _UNICODE
++  inline const wchar_t* GetSystemString(const wchar_t* unicodeString)
++    { return unicodeString;}
++  inline const UString& GetSystemString(const UString &unicodeString)
++    { return unicodeString;}
++  inline const wchar_t* GetSystemString(const wchar_t* unicodeString, UINT codePage)
++    { return unicodeString;}
++  inline const UString& GetSystemString(const UString &unicodeString, UINT codePage)
++    { return unicodeString;}
++  inline UString GetSystemString(const AString &multiByteString, UINT codePage)
++    { return MultiByteToUnicodeString(multiByteString, codePage);}
++  inline UString GetSystemString(const AString &multiByteString)
++    { return MultiByteToUnicodeString(multiByteString);}
++#else
++  inline const char* GetSystemString(const char *ansiString)
++    { return ansiString; }
++  inline const AString& GetSystemString(const AString &multiByteString, UINT)
++    { return multiByteString; }
++  inline const char * GetSystemString(const char *multiByteString, UINT)
++    { return multiByteString; }
++  inline AString GetSystemString(const UString &unicodeString)
++    { return UnicodeStringToMultiByte(unicodeString); }
++  inline AString GetSystemString(const UString &unicodeString, UINT codePage)
++    { return UnicodeStringToMultiByte(unicodeString, codePage); }
++#endif
++
++#ifndef _WIN32_WCE
++AString SystemStringToOemString(const CSysString &srcString);
++#endif
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp
+new file mode 100644
+index 0000000..1fa8ef2
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp
 @@ -0,0 +1,68 @@
 +// Common/StringToInt.cpp
 +
@@ -33616,9 +33551,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +    return -(Int64)ConvertStringToUInt64(s + 1, end);
 +  return ConvertStringToUInt64(s, end);
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h
+new file mode 100644
+index 0000000..bb971f6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h
 @@ -0,0 +1,17 @@
 +// Common/StringToInt.h
 +
@@ -33637,9 +33574,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h
+new file mode 100644
+index 0000000..0bf66e0
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h
 @@ -0,0 +1,19 @@
 +// Common/Types.h
 +
@@ -33660,9 +33599,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp
+new file mode 100644
+index 0000000..cb3d875
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp
 @@ -0,0 +1,74 @@
 +// Common/Vector.cpp
 +
@@ -33738,9 +33679,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +    _size -= num;
 +  }
 +}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h b/squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h
+new file mode 100644
+index 0000000..984fddc
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h
 @@ -0,0 +1,211 @@
 +// Common/Vector.h
 +
@@ -33953,9 +33896,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +};
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h b/squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h
+new file mode 100644
+index 0000000..c0038d6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h
 @@ -0,0 +1,18 @@
 +// Windows/Defs.h
 +
@@ -33975,9 +33920,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.
 +  { return (value != VARIANT_FALSE); }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp b/squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp
+new file mode 100644
+index 0000000..203de84
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp
 @@ -0,0 +1,245 @@
 +// Windows/FileIO.cpp
 +
@@ -34224,9 +34171,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +}
 +
 +}}}
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h b/squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h
+new file mode 100644
+index 0000000..1801484
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h
 @@ -0,0 +1,98 @@
 +// Windows/FileIO.h
 +
@@ -34326,9 +34275,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +}}}
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h b/squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h
+new file mode 100644
+index 0000000..e7924c8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -34339,9 +34290,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAf
 +#include "../Common/NewHandler.h"
 +
 +#endif 
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squashfs-tools-patched/LZMA/lzmadaptive/CPL.html
---- squashfs-tools/LZMA/lzmadaptive/CPL.html	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/CPL.html b/squashfs-tools/LZMA/lzmadaptive/CPL.html
+new file mode 100644
+index 0000000..ea1c247
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/CPL.html
 @@ -0,0 +1,224 @@
 +<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 +<HTML><HEAD><TITLE>Common Public License - v 1.0</TITLE>
@@ -34567,160 +34520,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squash
 +any resulting litigation.</FONT> 
 +<P><FONT size=2></FONT><FONT size=2></FONT>
 +<P><FONT size=2></FONT></P></BODY></HTML>
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squashfs-tools-patched/LZMA/lzmadaptive/history.txt
---- squashfs-tools/LZMA/lzmadaptive/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2016-08-25 09:06:03.223530354 -0400
-@@ -0,0 +1,147 @@
-+HISTORY of the LZMA SDK
-+-----------------------
-+
-+  Version 4.32                2005-12-09
-+  --------------------------------------
-+    - Java version of LZMA SDK was included
-+
-+
-+  Version 4.30                2005-11-20
-+  --------------------------------------
-+    - Compression ratio was improved in -a2 mode
-+    - Speed optimizations for compressing in -a2 mode
-+    - -fb switch now supports values up to 273
-+    - Bug in 7z_C (7zIn.c) was fixed:
-+      It used Alloc/Free functions from different memory pools.
-+      So if program used two memory pools, it worked incorrectly.
-+    - 7z_C: .7z format supporting was improved
-+    - LZMA# SDK (C#.NET version) was included
-+
-+
-+  Version 4.27 (Updated)      2005-09-21
-+  --------------------------------------
-+   - Some GUIDs/interfaces in C++ were changed.
-+     IStream.h:
-+       ISequentialInStream::Read now works as old ReadPart
-+       ISequentialOutStream::Write now works as old WritePart
-+
-+  
-+  Version 4.27                2005-08-07
-+  --------------------------------------
-+    - Bug in LzmaDecodeSize.c was fixed:
-+       if _LZMA_IN_CB and _LZMA_OUT_READ were defined,
-+       decompressing worked incorrectly.
-+
-+
-+  Version 4.26                2005-08-05
-+  --------------------------------------
-+    - Fixes in 7z_C code and LzmaTest.c:
-+      previous versions could work incorrectly,
-+      if malloc(0) returns 0
-+
-+
-+  Version 4.23                2005-06-29
-+  --------------------------------------
-+    - Small fixes in C++ code
-+
-+
-+  Version 4.22                2005-06-10
-+  --------------------------------------
-+    - Small fixes
-+
-+
-+  Version 4.21                2005-06-08
-+  --------------------------------------
-+    - Interfaces for ANSI-C LZMA Decoder (LzmaDecode.c) were changed
-+    - New additional version of ANSI-C LZMA Decoder with zlib-like interface:
-+        - LzmaStateDecode.h
-+        - LzmaStateDecode.c
-+        - LzmaStateTest.c
-+    - ANSI-C LZMA Decoder now can decompress files larger than 4 GB
-+
-+  
-+  Version 4.17                2005-04-18
-+  --------------------------------------
-+    - New example for RAM->RAM compressing/decompressing: 
-+      LZMA + BCJ (filter for x86 code):
-+        - LzmaRam.h
-+        - LzmaRam.cpp
-+        - LzmaRamDecode.h
-+        - LzmaRamDecode.c
-+        - -f86 switch for lzma.exe
-+
-+  
-+  Version 4.16                2005-03-29
-+  --------------------------------------
-+    - Bug was fixed in LzmaDecode.c (ANSI-C LZMA Decoder): 
-+       If _LZMA_OUT_READ was defined, and if encoded stream was corrupted,
-+       decoder could access memory outside of allocated range.
-+    - Speed optimization of ANSI-C LZMA Decoder (now it's about 20% faster).
-+      Old version of LZMA Decoder now is in file LzmaDecodeSize.c. 
-+      LzmaDecodeSize.c can provide slightly smaller code than LzmaDecode.c
-+    - Small speed optimization in LZMA C++ code
-+    - filter for SPARC's code was added
-+    - Simplified version of .7z ANSI-C Decoder was included
-+
-+
-+  Version 4.06                2004-09-05
-+  --------------------------------------
-+    - Bug in v4.05 was fixed:
-+        LZMA-Encoder didn't release output stream in some cases.
-+
-+
-+  Version 4.05                2004-08-25
-+  --------------------------------------
-+    - Source code of filters for x86, IA-64, ARM, ARM-Thumb 
-+      and PowerPC code was included to SDK
-+    - Some internal minor changes
-+
-+
-+  Version 4.04                2004-07-28
-+  --------------------------------------
-+    - More compatibility with some C++ compilers
-+
-+
-+  Version 4.03                2004-06-18
-+  --------------------------------------
-+    - "Benchmark" command was added. It measures compressing 
-+      and decompressing speed and shows rating values. 
-+      Also it checks hardware errors.
-+
-+
-+  Version 4.02                2004-06-10
-+  --------------------------------------
-+    - C++ LZMA Encoder/Decoder code now is more portable
-+      and it can be compiled by GCC on Linux.
-+
-+
-+  Version 4.01                2004-02-15
-+  --------------------------------------
-+    - Some detection of data corruption was enabled.
-+        LzmaDecode.c / RangeDecoderReadByte
-+        .....
-+        {
-+          rd->ExtraBytes = 1;
-+          return 0xFF;
-+        }
-+
-+
-+  Version 4.00                2004-02-13
-+  --------------------------------------
-+    - Original version of LZMA SDK
-+
-+
-+
-+HISTORY of the LZMA
-+-------------------
-+  2001-2004:  Improvements to LZMA compressing/decompressing code, 
-+              keeping compatibility with original LZMA format
-+  1996-2001:  Development of LZMA compression format
-+
-+  Some milestones:
-+
-+  2001-08-30: LZMA compression was added to 7-Zip
-+  1999-01-02: First version of 7-Zip was released
-+  
-+
-+End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt
---- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2016-08-25 09:06:03.223530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/LGPL.txt b/squashfs-tools/LZMA/lzmadaptive/LGPL.txt
+new file mode 100644
+index 0000000..4c38901
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/LGPL.txt
 @@ -0,0 +1,504 @@
 +      GNU LESSER GENERAL PUBLIC LICENSE
 +           Version 2.1, February 1999
@@ -35226,9 +35030,284 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squash
 +That's all there is to it!
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt
---- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2016-08-25 09:06:03.223530354 -0400
+diff --git a/squashfs-tools/LZMA/lzmadaptive/Methods.txt b/squashfs-tools/LZMA/lzmadaptive/Methods.txt
+new file mode 100644
+index 0000000..34e1a5a
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/Methods.txt
+@@ -0,0 +1,114 @@
++Compression method IDs (4.27)
++-----------------------------
++
++Each compression method in 7z has unique binary value (ID).
++The length of ID in bytes is arbitrary but it can not exceed 15 bytes.
++
++List of defined IDs
++-------------------
++      
++00 - Copy
++01 - Reserved
++02 - Common
++   03 Swap
++      - 2 Swap2
++      - 4 Swap4
++   04 Delta (subject to change)
++
++03 - 7z
++   01 - LZMA
++      01 - Version
++  
++   03 - Branch
++      01 - x86
++         03  - BCJ
++         1B  - BCJ2
++      02 - PPC
++         05 - BC_PPC_B (Big Endian)
++      03 - Alpha
++         01 - BC_Alpha
++      04 - IA64
++         01 - BC_IA64
++      05 - ARM
++         01 - BC_ARM
++      06 - M68
++         05 - BC_M68_B (Big Endian)
++      07 - ARM Thumb
++         01 - BC_ARMThumb
++      08 - SPARC
++         05 - BC_SPARC
++
++   04 - PPMD
++      01 - Version
++
++04 - Misc
++   00 - Reserved
++   01 - Zip
++      00 - Copy (not used). Use {00} instead
++      01 - Shrink
++      06 - Implode
++      08 - Deflate
++      09 - Deflate64
++      12 - BZip2 (not used). Use {04 02 02} instead
++   02 - BZip
++      02 - BZip2
++   03 - Rar
++      01 - Rar15
++      02 - Rar20
++      03 - Rar29
++   04 - Arj
++      01 - Arj (1,2,3)
++      02 - Arj 4
++   05 - Z
++   06 - Lzh
++   07 - Reserved for 7z
++   08 - Cab
++
++
++06 - Crypto 
++   00 - 
++   01 - AES
++      0x - AES-128
++      4x - AES-192
++      8x - AES-256
++
++      x0 - ECB
++      x1 - CBC
++      x2 - CFB
++      x3 - OFB
++
++   07 - Reserved
++   0F - Reserved
++
++   F0 - Misc Ciphers (Real Ciphers without hashing algo)
++
++   F1 - Misc Ciphers (Combine)
++      01 - Zip
++         01 - Main Zip crypto algo
++      03 - RAR
++         02 - 
++         03 - Rar29 AES-128 + (modified SHA-1)
++      07 - 7z
++         01 - AES-256 + SHA-256
++
++07 - Hash (subject to change)
++   00 - 
++   01 - CRC
++   02 - SHA-1
++   03 - SHA-256
++   04 - SHA-384
++   05 - SHA-512
++
++   F0 - Misc Hash
++
++   F1 - Misc
++      03 - RAR
++         03 - Rar29 Password Hashing (modified SHA1)
++      07 - 7z 
++         01 - SHA-256 Password Hashing
++    
++   
++
++
++---
++End of document
+diff --git a/squashfs-tools/LZMA/lzmadaptive/history.txt b/squashfs-tools/LZMA/lzmadaptive/history.txt
+new file mode 100644
+index 0000000..ac391c7
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/history.txt
+@@ -0,0 +1,147 @@
++HISTORY of the LZMA SDK
++-----------------------
++
++  Version 4.32                2005-12-09
++  --------------------------------------
++    - Java version of LZMA SDK was included
++
++
++  Version 4.30                2005-11-20
++  --------------------------------------
++    - Compression ratio was improved in -a2 mode
++    - Speed optimizations for compressing in -a2 mode
++    - -fb switch now supports values up to 273
++    - Bug in 7z_C (7zIn.c) was fixed:
++      It used Alloc/Free functions from different memory pools.
++      So if program used two memory pools, it worked incorrectly.
++    - 7z_C: .7z format supporting was improved
++    - LZMA# SDK (C#.NET version) was included
++
++
++  Version 4.27 (Updated)      2005-09-21
++  --------------------------------------
++   - Some GUIDs/interfaces in C++ were changed.
++     IStream.h:
++       ISequentialInStream::Read now works as old ReadPart
++       ISequentialOutStream::Write now works as old WritePart
++
++  
++  Version 4.27                2005-08-07
++  --------------------------------------
++    - Bug in LzmaDecodeSize.c was fixed:
++       if _LZMA_IN_CB and _LZMA_OUT_READ were defined,
++       decompressing worked incorrectly.
++
++
++  Version 4.26                2005-08-05
++  --------------------------------------
++    - Fixes in 7z_C code and LzmaTest.c:
++      previous versions could work incorrectly,
++      if malloc(0) returns 0
++
++
++  Version 4.23                2005-06-29
++  --------------------------------------
++    - Small fixes in C++ code
++
++
++  Version 4.22                2005-06-10
++  --------------------------------------
++    - Small fixes
++
++
++  Version 4.21                2005-06-08
++  --------------------------------------
++    - Interfaces for ANSI-C LZMA Decoder (LzmaDecode.c) were changed
++    - New additional version of ANSI-C LZMA Decoder with zlib-like interface:
++        - LzmaStateDecode.h
++        - LzmaStateDecode.c
++        - LzmaStateTest.c
++    - ANSI-C LZMA Decoder now can decompress files larger than 4 GB
++
++  
++  Version 4.17                2005-04-18
++  --------------------------------------
++    - New example for RAM->RAM compressing/decompressing: 
++      LZMA + BCJ (filter for x86 code):
++        - LzmaRam.h
++        - LzmaRam.cpp
++        - LzmaRamDecode.h
++        - LzmaRamDecode.c
++        - -f86 switch for lzma.exe
++
++  
++  Version 4.16                2005-03-29
++  --------------------------------------
++    - Bug was fixed in LzmaDecode.c (ANSI-C LZMA Decoder): 
++       If _LZMA_OUT_READ was defined, and if encoded stream was corrupted,
++       decoder could access memory outside of allocated range.
++    - Speed optimization of ANSI-C LZMA Decoder (now it's about 20% faster).
++      Old version of LZMA Decoder now is in file LzmaDecodeSize.c. 
++      LzmaDecodeSize.c can provide slightly smaller code than LzmaDecode.c
++    - Small speed optimization in LZMA C++ code
++    - filter for SPARC's code was added
++    - Simplified version of .7z ANSI-C Decoder was included
++
++
++  Version 4.06                2004-09-05
++  --------------------------------------
++    - Bug in v4.05 was fixed:
++        LZMA-Encoder didn't release output stream in some cases.
++
++
++  Version 4.05                2004-08-25
++  --------------------------------------
++    - Source code of filters for x86, IA-64, ARM, ARM-Thumb 
++      and PowerPC code was included to SDK
++    - Some internal minor changes
++
++
++  Version 4.04                2004-07-28
++  --------------------------------------
++    - More compatibility with some C++ compilers
++
++
++  Version 4.03                2004-06-18
++  --------------------------------------
++    - "Benchmark" command was added. It measures compressing 
++      and decompressing speed and shows rating values. 
++      Also it checks hardware errors.
++
++
++  Version 4.02                2004-06-10
++  --------------------------------------
++    - C++ LZMA Encoder/Decoder code now is more portable
++      and it can be compiled by GCC on Linux.
++
++
++  Version 4.01                2004-02-15
++  --------------------------------------
++    - Some detection of data corruption was enabled.
++        LzmaDecode.c / RangeDecoderReadByte
++        .....
++        {
++          rd->ExtraBytes = 1;
++          return 0xFF;
++        }
++
++
++  Version 4.00                2004-02-13
++  --------------------------------------
++    - Original version of LZMA SDK
++
++
++
++HISTORY of the LZMA
++-------------------
++  2001-2004:  Improvements to LZMA compressing/decompressing code, 
++              keeping compatibility with original LZMA format
++  1996-2001:  Development of LZMA compression format
++
++  Some milestones:
++
++  2001-08-30: LZMA compression was added to 7-Zip
++  1999-01-02: First version of 7-Zip was released
++  
++
++End of document
+diff --git a/squashfs-tools/LZMA/lzmadaptive/lzma.txt b/squashfs-tools/LZMA/lzmadaptive/lzma.txt
+new file mode 100644
+index 0000000..4702102
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmadaptive/lzma.txt
 @@ -0,0 +1,637 @@
 +LZMA SDK 4.32
 +-------------
@@ -35867,127 +35946,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squash
 +
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt
---- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,114 @@
-+Compression method IDs (4.27)
-+-----------------------------
-+
-+Each compression method in 7z has unique binary value (ID).
-+The length of ID in bytes is arbitrary but it can not exceed 15 bytes.
-+
-+List of defined IDs
-+-------------------
-+      
-+00 - Copy
-+01 - Reserved
-+02 - Common
-+   03 Swap
-+      - 2 Swap2
-+      - 4 Swap4
-+   04 Delta (subject to change)
-+
-+03 - 7z
-+   01 - LZMA
-+      01 - Version
-+  
-+   03 - Branch
-+      01 - x86
-+         03  - BCJ
-+         1B  - BCJ2
-+      02 - PPC
-+         05 - BC_PPC_B (Big Endian)
-+      03 - Alpha
-+         01 - BC_Alpha
-+      04 - IA64
-+         01 - BC_IA64
-+      05 - ARM
-+         01 - BC_ARM
-+      06 - M68
-+         05 - BC_M68_B (Big Endian)
-+      07 - ARM Thumb
-+         01 - BC_ARMThumb
-+      08 - SPARC
-+         05 - BC_SPARC
-+
-+   04 - PPMD
-+      01 - Version
-+
-+04 - Misc
-+   00 - Reserved
-+   01 - Zip
-+      00 - Copy (not used). Use {00} instead
-+      01 - Shrink
-+      06 - Implode
-+      08 - Deflate
-+      09 - Deflate64
-+      12 - BZip2 (not used). Use {04 02 02} instead
-+   02 - BZip
-+      02 - BZip2
-+   03 - Rar
-+      01 - Rar15
-+      02 - Rar20
-+      03 - Rar29
-+   04 - Arj
-+      01 - Arj (1,2,3)
-+      02 - Arj 4
-+   05 - Z
-+   06 - Lzh
-+   07 - Reserved for 7z
-+   08 - Cab
-+
-+
-+06 - Crypto 
-+   00 - 
-+   01 - AES
-+      0x - AES-128
-+      4x - AES-192
-+      8x - AES-256
-+
-+      x0 - ECB
-+      x1 - CBC
-+      x2 - CFB
-+      x3 - OFB
-+
-+   07 - Reserved
-+   0F - Reserved
-+
-+   F0 - Misc Ciphers (Real Ciphers without hashing algo)
-+
-+   F1 - Misc Ciphers (Combine)
-+      01 - Zip
-+         01 - Main Zip crypto algo
-+      03 - RAR
-+         02 - 
-+         03 - Rar29 AES-128 + (modified SHA-1)
-+      07 - 7z
-+         01 - AES-256 + SHA-256
-+
-+07 - Hash (subject to change)
-+   00 - 
-+   01 - CRC
-+   02 - SHA-1
-+   03 - SHA-256
-+   04 - SHA-384
-+   05 - SHA-512
-+
-+   F0 - Misc Hash
-+
-+   F1 - Misc
-+      03 - RAR
-+         03 - Rar29 Password Hashing (modified SHA1)
-+      07 - 7z 
-+         01 - SHA-256 Password Hashing
-+    
-+   
-+
-+
-+---
-+End of document
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-tools-patched/LZMA/lzmalt/7zlzma.c
---- squashfs-tools/LZMA/lzmalt/7zlzma.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/7zlzma.c b/squashfs-tools/LZMA/lzmalt/7zlzma.c
+new file mode 100644
+index 0000000..0d1c870
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/7zlzma.c
 @@ -0,0 +1,58 @@
 +#include "lzmalt.h"
 +
@@ -36047,9 +36010,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-to
 +#endif
 +
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h
---- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/AriBitCoder.h b/squashfs-tools/LZMA/lzmalt/AriBitCoder.h
+new file mode 100644
+index 0000000..cedc189
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/AriBitCoder.h
 @@ -0,0 +1,51 @@
 +#ifndef __COMPRESSION_BITCODER_H
 +#define __COMPRESSION_BITCODER_H
@@ -36102,9 +36067,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squash
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h
---- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/BitTreeCoder.h b/squashfs-tools/LZMA/lzmalt/BitTreeCoder.h
+new file mode 100644
+index 0000000..8c663e6
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/BitTreeCoder.h
 @@ -0,0 +1,160 @@
 +#ifndef __BITTREECODER_H
 +#define __BITTREECODER_H
@@ -36266,9 +36233,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squas
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/IInOutStreams.c b/squashfs-tools/LZMA/lzmalt/IInOutStreams.c
+new file mode 100644
+index 0000000..9fc0800
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/IInOutStreams.c
 @@ -0,0 +1,39 @@
 +#include "stdlib.h"
 +#include "IInOutStreams.h"
@@ -36309,9 +36278,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squa
 +        return (BYTE) *in_stream.data++;
 +    }
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/IInOutStreams.h b/squashfs-tools/LZMA/lzmalt/IInOutStreams.h
+new file mode 100644
+index 0000000..69abf39
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/IInOutStreams.h
 @@ -0,0 +1,62 @@
 +#ifndef __IINOUTSTREAMS_H
 +#define __IINOUTSTREAMS_H
@@ -36375,238 +36346,100 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squa
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-tools-patched/LZMA/lzmalt/LenCoder.h
---- squashfs-tools/LZMA/lzmalt/LenCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,75 @@
-+#ifndef __LENCODER_H
-+#define __LENCODER_H
+diff --git a/squashfs-tools/LZMA/lzmalt/LZMA.h b/squashfs-tools/LZMA/lzmalt/LZMA.h
+new file mode 100644
+index 0000000..368328c
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/LZMA.h
+@@ -0,0 +1,83 @@
++#include "LenCoder.h"
 +
-+#include "BitTreeCoder.h"
-+
-+
-+#define kNumPosStatesBitsMax 4
-+#define kNumPosStatesMax 16
++#ifndef __LZMA_H
++#define __LZMA_H
 +
 +
-+#define kNumPosStatesBitsEncodingMax 4
-+#define kNumPosStatesEncodingMax 16
++#define kNumRepDistances 4
++
++#define kNumStates 12
++
++static const BYTE kLiteralNextStates[kNumStates] = {0, 0, 0, 0, 1, 2, 3, 4,  5,  6,   4, 5};
++static const BYTE kMatchNextStates[kNumStates]   = {7, 7, 7, 7, 7, 7, 7, 10, 10, 10, 10, 10};
++static const BYTE kRepNextStates[kNumStates]     = {8, 8, 8, 8, 8, 8, 8, 11, 11, 11, 11, 11};
++static const BYTE kShortRepNextStates[kNumStates]= {9, 9, 9, 9, 9, 9, 9, 11, 11, 11, 11, 11};
++
++typedef BYTE CState;
++
++INLINE void CStateInit(CState *m_Index)
++    { *m_Index = 0; }
++INLINE void CStateUpdateChar(CState *m_Index)
++    { *m_Index = kLiteralNextStates[*m_Index]; }
++INLINE void CStateUpdateMatch(CState *m_Index)
++    { *m_Index = kMatchNextStates[*m_Index]; }
++INLINE void CStateUpdateRep(CState *m_Index)
++    { *m_Index = kRepNextStates[*m_Index]; }
++INLINE void CStateUpdateShortRep(CState *m_Index)
++    { *m_Index = kShortRepNextStates[*m_Index]; }
 +
 +
-+//#define kNumMoveBits 5
++#define kNumPosSlotBits 6
++#define kDicLogSizeMax 28
++#define kDistTableSizeMax 56
 +
-+#define kNumLenBits 3
-+#define kNumLowSymbols (1 << kNumLenBits)
-+
-+#define kNumMidBits 3
-+#define kNumMidSymbols (1 << kNumMidBits)
-+
-+#define kNumHighBits 8
-+
-+#define kNumSymbolsTotal (kNumLowSymbols + kNumMidSymbols + (1 << kNumHighBits))
-+
-+typedef struct LenDecoder
++//extern UINT32 kDistStart[kDistTableSizeMax];
++static const BYTE kDistDirectBits[kDistTableSizeMax] = 
 +{
-+  CBitDecoder       m_Choice;
-+  CBitDecoder       m_Choice2;
-+  CBitTreeDecoder   m_LowCoder[kNumPosStatesMax];
-+  CBitTreeDecoder   m_MidCoder[kNumPosStatesMax];
-+  CBitTreeDecoder   m_HighCoder; 
-+  UINT32            m_NumPosStates;
-+} LenDecoder;
++  0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9,
++  10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 
++  20, 20, 21, 21, 22, 22, 23, 23, 24, 24, 25, 25, 26, 26 
++};
 +
-+INLINE void LenDecoderCreate(LenDecoder *lenCoder, UINT32 aNumPosStates)
-+  { 
-+    lenCoder->m_NumPosStates = aNumPosStates; 
-+  }
-+
-+INLINE void LenDecoderInit(LenDecoder *lenCoder)
-+  {
-+    UINT32 aPosState;
-+    BitDecoderInit(&lenCoder->m_Choice);
-+    for (aPosState = 0; aPosState < lenCoder->m_NumPosStates; aPosState++)
-+    {
-+      BitTreeDecoderInit(&lenCoder->m_LowCoder[aPosState],kNumLenBits);
-+      BitTreeDecoderInit(&lenCoder->m_MidCoder[aPosState],kNumMidBits);
-+    }
-+    BitTreeDecoderInit(&lenCoder->m_HighCoder,kNumHighBits);
-+    BitDecoderInit(&lenCoder->m_Choice2);
-+  }
-+
-+INLINE UINT32 LenDecode(ISequentialInStream *in_stream, LenDecoder *lenCoder, CRangeDecoder *aRangeDecoder, UINT32 aPosState)
-+  {
-+    if(BitDecode(in_stream, &lenCoder->m_Choice, aRangeDecoder) == 0)
-+      return BitTreeDecode(in_stream, &lenCoder->m_LowCoder[aPosState],aRangeDecoder);
-+    else
-+    {
-+      UINT32 aSymbol = kNumLowSymbols;
-+      if(BitDecode(in_stream, &lenCoder->m_Choice2, aRangeDecoder) == 0)
-+        aSymbol += BitTreeDecode(in_stream, &lenCoder->m_MidCoder[aPosState],aRangeDecoder);
-+      else
-+      {
-+        aSymbol += kNumMidSymbols;
-+        aSymbol += BitTreeDecode(in_stream, &lenCoder->m_HighCoder,aRangeDecoder);
-+      }
-+      return aSymbol;
-+    }
-+  }
-+
-+
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h
---- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,146 @@
-+#ifndef __LITERALCODER_H
-+#define __LITERALCODER_H
-+
-+#include "AriBitCoder.h"
-+#include "RCDefs.h"
-+
-+//BRCM modification start
-+#ifdef _HOST_TOOL
-+#include "stdio.h"
-+#include "malloc.h" 
-+#endif
-+
-+#ifdef _CFE_
-+#include "lib_malloc.h"
-+#include "lib_printf.h"
-+#define malloc(x) KMALLOC(x, 0)
-+#define free(x) KFREE(x)
-+#endif
-+
-+#ifdef __KERNEL__
-+#include <linux/kernel.h>
-+#include <linux/slab.h>
-+#define printf  printk
-+//#define malloc(x)  kmalloc(x,GFP_KERNEL)
-+#define malloc(x)  vmalloc(x)
-+#define free(x) vfree(x)
-+#endif
-+//BRCM modification end
-+
-+//#define kNumMoveBits 5
-+
-+typedef struct LitDecoder2
++#define kNumLenToPosStates 4
++INLINE UINT32 GetLenToPosState(UINT32 aLen)
 +{
-+  CBitDecoder m_Decoders[3][1 << 8];
-+} LitDecoder2;
++  aLen -= 2;
++  if (aLen < kNumLenToPosStates)
++    return aLen;
++  return kNumLenToPosStates - 1;
++}
++
++#define kMatchMinLen 2
++
++#define kMatchMaxLen (kMatchMinLen + kNumSymbolsTotal - 1)
++
++#define kNumAlignBits 4
++#define kAlignTableSize 16
++#define kAlignMask 15
++
++#define kStartPosModelIndex 4
++#define kEndPosModelIndex 14
++#define kNumPosModels 10
++
++#define kNumFullDistances (1 << (kEndPosModelIndex / 2))
 +
 +
-+INLINE void LitDecoder2Init(LitDecoder2 *litDecoder2)
-+  {
-+    int i, j;
-+    for (i = 0; i < 3; i++)
-+      for (j = 1; j < (1 << 8); j++)
-+        BitDecoderInit(&litDecoder2->m_Decoders[i][j]);
-+  }
++#define kMainChoiceLiteralIndex 0
++#define kMainChoiceMatchIndex 1
 +
-+INLINE BYTE LitDecoder2DecodeNormal(ISequentialInStream *in_stream, LitDecoder2 *litDecoder2, CRangeDecoder *aRangeDecoder)
-+  {
-+    UINT32 aSymbol = 1;
-+    UINT32 aRange = aRangeDecoder->m_Range;
-+    UINT32 aCode = aRangeDecoder->m_Code;        
-+    do
-+    {
-+      RC_GETBIT(kNumMoveBits, litDecoder2->m_Decoders[0][aSymbol], aSymbol)
-+    }
-+    while (aSymbol < 0x100);
-+    aRangeDecoder->m_Range = aRange;
-+    aRangeDecoder->m_Code = aCode;
-+    return aSymbol;
-+  }
++#define kMatchChoiceDistanceIndex0
++#define kMatchChoiceRepetitionIndex 1
 +
-+INLINE BYTE LitDecoder2DecodeWithMatchByte(ISequentialInStream *in_stream, LitDecoder2 *litDecoder2, CRangeDecoder *aRangeDecoder, BYTE aMatchByte)
-+  {
-+    UINT32 aSymbol = 1;
-+    UINT32 aRange = aRangeDecoder->m_Range;
-+    UINT32 aCode = aRangeDecoder->m_Code;        
-+    do
-+    {
-+      UINT32 aBit;
-+      UINT32 aMatchBit = (aMatchByte >> 7) & 1;
-+      aMatchByte <<= 1;
-+      RC_GETBIT2(kNumMoveBits, litDecoder2->m_Decoders[1 + aMatchBit][aSymbol], aSymbol, 
-+          aBit = 0, aBit = 1)
-+      if (aMatchBit != aBit)
-+      {
-+        while (aSymbol < 0x100)
-+        {
-+          RC_GETBIT(kNumMoveBits, litDecoder2->m_Decoders[0][aSymbol], aSymbol)
-+        }
-+        break;
-+      }
-+    }
-+    while (aSymbol < 0x100);
-+    aRangeDecoder->m_Range = aRange;
-+    aRangeDecoder->m_Code = aCode;
-+    return aSymbol;
-+  }
++#define kNumMoveBitsForMainChoice 5
++#define kNumMoveBitsForPosCoders 5
 +
++#define kNumMoveBitsForAlignCoders 5
 +
-+typedef struct LitDecoder
-+{
-+  LitDecoder2 *m_Coders;
-+  UINT32 m_NumPrevBits;
-+  UINT32 m_NumPosBits;
-+  UINT32 m_PosMask;
-+} LitDecoder;
++#define kNumMoveBitsForPosSlotCoder 5
 +
++#define kNumLitPosStatesBitsEncodingMax 4
++#define kNumLitContextBitsMax 8
 +
-+//  LitDecoder(): m_Coders(0) {}
-+//  ~LitDecoder()  { Free(); }
-+
-+/*
-+INLINE void LitDecoderFree(LitDecoder *litDecoder)
-+  { 
-+    free( (char *) litDecoder->m_Coders );
-+    litDecoder->m_Coders = 0;
-+  }
-+*/
-+
-+INLINE void LitDecoderCreate(LitDecoder *litDecoder, UINT32 aNumPosBits, UINT32 aNumPrevBits)
-+  {
-+//    LitDecoderFree(litDecoder);
-+    UINT32 aNumStates;
-+    litDecoder->m_NumPosBits = aNumPosBits;
-+    litDecoder->m_PosMask = (1 << aNumPosBits) - 1;
-+    litDecoder->m_NumPrevBits = aNumPrevBits;
-+    aNumStates = 1 << (aNumPrevBits + aNumPosBits);
-+    litDecoder->m_Coders = (LitDecoder2*) malloc( sizeof( LitDecoder2 ) * aNumStates );
-+    //printf("malloc in LitDecoderCreate=%d\n",sizeof( LitDecoder2 ) * aNumStates);
-+    if (litDecoder->m_Coders == 0)
-+        printf( "Error allocating memory for LitDecoder m_Coders!\n" );
-+  }
-+
-+INLINE void LitDecoderInit(LitDecoder *litDecoder)
-+  {
-+    UINT32 i;
-+    UINT32 aNumStates = 1 << (litDecoder->m_NumPrevBits + litDecoder->m_NumPosBits);
-+    for (i = 0; i < aNumStates; i++)
-+      LitDecoder2Init(&litDecoder->m_Coders[i]);
-+  }
-+
-+INLINE UINT32 LitDecoderGetState(LitDecoder *litDecoder, UINT32 aPos, BYTE aPrevByte)
-+  { 
-+    return ((aPos & litDecoder->m_PosMask) << litDecoder->m_NumPrevBits) + (aPrevByte >> (8 - litDecoder->m_NumPrevBits)); 
-+  }
-+
-+INLINE BYTE LitDecodeNormal(ISequentialInStream *in_stream, LitDecoder *litDecoder, CRangeDecoder *aRangeDecoder, UINT32 aPos, BYTE aPrevByte)
-+  { 
-+    return LitDecoder2DecodeNormal(in_stream, &litDecoder->m_Coders[LitDecoderGetState(litDecoder, aPos, aPrevByte)], aRangeDecoder); 
-+  }
-+
-+INLINE BYTE LitDecodeWithMatchByte(ISequentialInStream *in_stream, LitDecoder *litDecoder, CRangeDecoder *aRangeDecoder, UINT32 aPos, BYTE aPrevByte, BYTE aMatchByte)
-+  { 
-+      return LitDecoder2DecodeWithMatchByte(in_stream, &litDecoder->m_Coders[LitDecoderGetState(litDecoder, aPos, aPrevByte)], aRangeDecoder, aMatchByte); 
-+  }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/LZMADecoder.c b/squashfs-tools/LZMA/lzmalt/LZMADecoder.c
+new file mode 100644
+index 0000000..e12e205
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/LZMADecoder.c
 @@ -0,0 +1,417 @@
 +#include "Portable.h"
 +#include "stdio.h"
@@ -37025,9 +36858,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squash
 +  return S_OK;
 +}
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/LZMADecoder.h b/squashfs-tools/LZMA/lzmalt/LZMADecoder.h
+new file mode 100644
+index 0000000..76fa536
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/LZMADecoder.h
 @@ -0,0 +1,60 @@
 +#ifndef __LZARITHMETIC_DECODER_H
 +#define __LZARITHMETIC_DECODER_H
@@ -37089,116 +36924,244 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squash
 +
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tools-patched/LZMA/lzmalt/LZMA.h
---- squashfs-tools/LZMA/lzmalt/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,83 @@
-+#include "LenCoder.h"
+diff --git a/squashfs-tools/LZMA/lzmalt/LenCoder.h b/squashfs-tools/LZMA/lzmalt/LenCoder.h
+new file mode 100644
+index 0000000..40552b8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/LenCoder.h
+@@ -0,0 +1,75 @@
++#ifndef __LENCODER_H
++#define __LENCODER_H
 +
-+#ifndef __LZMA_H
-+#define __LZMA_H
-+
-+
-+#define kNumRepDistances 4
-+
-+#define kNumStates 12
-+
-+static const BYTE kLiteralNextStates[kNumStates] = {0, 0, 0, 0, 1, 2, 3, 4,  5,  6,   4, 5};
-+static const BYTE kMatchNextStates[kNumStates]   = {7, 7, 7, 7, 7, 7, 7, 10, 10, 10, 10, 10};
-+static const BYTE kRepNextStates[kNumStates]     = {8, 8, 8, 8, 8, 8, 8, 11, 11, 11, 11, 11};
-+static const BYTE kShortRepNextStates[kNumStates]= {9, 9, 9, 9, 9, 9, 9, 11, 11, 11, 11, 11};
-+
-+typedef BYTE CState;
-+
-+INLINE void CStateInit(CState *m_Index)
-+    { *m_Index = 0; }
-+INLINE void CStateUpdateChar(CState *m_Index)
-+    { *m_Index = kLiteralNextStates[*m_Index]; }
-+INLINE void CStateUpdateMatch(CState *m_Index)
-+    { *m_Index = kMatchNextStates[*m_Index]; }
-+INLINE void CStateUpdateRep(CState *m_Index)
-+    { *m_Index = kRepNextStates[*m_Index]; }
-+INLINE void CStateUpdateShortRep(CState *m_Index)
-+    { *m_Index = kShortRepNextStates[*m_Index]; }
++#include "BitTreeCoder.h"
 +
 +
-+#define kNumPosSlotBits 6
-+#define kDicLogSizeMax 28
-+#define kDistTableSizeMax 56
++#define kNumPosStatesBitsMax 4
++#define kNumPosStatesMax 16
 +
-+//extern UINT32 kDistStart[kDistTableSizeMax];
-+static const BYTE kDistDirectBits[kDistTableSizeMax] = 
++
++#define kNumPosStatesBitsEncodingMax 4
++#define kNumPosStatesEncodingMax 16
++
++
++//#define kNumMoveBits 5
++
++#define kNumLenBits 3
++#define kNumLowSymbols (1 << kNumLenBits)
++
++#define kNumMidBits 3
++#define kNumMidSymbols (1 << kNumMidBits)
++
++#define kNumHighBits 8
++
++#define kNumSymbolsTotal (kNumLowSymbols + kNumMidSymbols + (1 << kNumHighBits))
++
++typedef struct LenDecoder
 +{
-+  0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9,
-+  10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 
-+  20, 20, 21, 21, 22, 22, 23, 23, 24, 24, 25, 25, 26, 26 
-+};
++  CBitDecoder       m_Choice;
++  CBitDecoder       m_Choice2;
++  CBitTreeDecoder   m_LowCoder[kNumPosStatesMax];
++  CBitTreeDecoder   m_MidCoder[kNumPosStatesMax];
++  CBitTreeDecoder   m_HighCoder; 
++  UINT32            m_NumPosStates;
++} LenDecoder;
 +
-+#define kNumLenToPosStates 4
-+INLINE UINT32 GetLenToPosState(UINT32 aLen)
++INLINE void LenDecoderCreate(LenDecoder *lenCoder, UINT32 aNumPosStates)
++  { 
++    lenCoder->m_NumPosStates = aNumPosStates; 
++  }
++
++INLINE void LenDecoderInit(LenDecoder *lenCoder)
++  {
++    UINT32 aPosState;
++    BitDecoderInit(&lenCoder->m_Choice);
++    for (aPosState = 0; aPosState < lenCoder->m_NumPosStates; aPosState++)
++    {
++      BitTreeDecoderInit(&lenCoder->m_LowCoder[aPosState],kNumLenBits);
++      BitTreeDecoderInit(&lenCoder->m_MidCoder[aPosState],kNumMidBits);
++    }
++    BitTreeDecoderInit(&lenCoder->m_HighCoder,kNumHighBits);
++    BitDecoderInit(&lenCoder->m_Choice2);
++  }
++
++INLINE UINT32 LenDecode(ISequentialInStream *in_stream, LenDecoder *lenCoder, CRangeDecoder *aRangeDecoder, UINT32 aPosState)
++  {
++    if(BitDecode(in_stream, &lenCoder->m_Choice, aRangeDecoder) == 0)
++      return BitTreeDecode(in_stream, &lenCoder->m_LowCoder[aPosState],aRangeDecoder);
++    else
++    {
++      UINT32 aSymbol = kNumLowSymbols;
++      if(BitDecode(in_stream, &lenCoder->m_Choice2, aRangeDecoder) == 0)
++        aSymbol += BitTreeDecode(in_stream, &lenCoder->m_MidCoder[aPosState],aRangeDecoder);
++      else
++      {
++        aSymbol += kNumMidSymbols;
++        aSymbol += BitTreeDecode(in_stream, &lenCoder->m_HighCoder,aRangeDecoder);
++      }
++      return aSymbol;
++    }
++  }
++
++
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmalt/LiteralCoder.h b/squashfs-tools/LZMA/lzmalt/LiteralCoder.h
+new file mode 100644
+index 0000000..2b1670d
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/LiteralCoder.h
+@@ -0,0 +1,146 @@
++#ifndef __LITERALCODER_H
++#define __LITERALCODER_H
++
++#include "AriBitCoder.h"
++#include "RCDefs.h"
++
++//BRCM modification start
++#ifdef _HOST_TOOL
++#include "stdio.h"
++#include "malloc.h" 
++#endif
++
++#ifdef _CFE_
++#include "lib_malloc.h"
++#include "lib_printf.h"
++#define malloc(x) KMALLOC(x, 0)
++#define free(x) KFREE(x)
++#endif
++
++#ifdef __KERNEL__
++#include <linux/kernel.h>
++#include <linux/slab.h>
++#define printf  printk
++//#define malloc(x)  kmalloc(x,GFP_KERNEL)
++#define malloc(x)  vmalloc(x)
++#define free(x) vfree(x)
++#endif
++//BRCM modification end
++
++//#define kNumMoveBits 5
++
++typedef struct LitDecoder2
 +{
-+  aLen -= 2;
-+  if (aLen < kNumLenToPosStates)
-+    return aLen;
-+  return kNumLenToPosStates - 1;
-+}
-+
-+#define kMatchMinLen 2
-+
-+#define kMatchMaxLen (kMatchMinLen + kNumSymbolsTotal - 1)
-+
-+#define kNumAlignBits 4
-+#define kAlignTableSize 16
-+#define kAlignMask 15
-+
-+#define kStartPosModelIndex 4
-+#define kEndPosModelIndex 14
-+#define kNumPosModels 10
-+
-+#define kNumFullDistances (1 << (kEndPosModelIndex / 2))
++  CBitDecoder m_Decoders[3][1 << 8];
++} LitDecoder2;
 +
 +
-+#define kMainChoiceLiteralIndex 0
-+#define kMainChoiceMatchIndex 1
++INLINE void LitDecoder2Init(LitDecoder2 *litDecoder2)
++  {
++    int i, j;
++    for (i = 0; i < 3; i++)
++      for (j = 1; j < (1 << 8); j++)
++        BitDecoderInit(&litDecoder2->m_Decoders[i][j]);
++  }
 +
-+#define kMatchChoiceDistanceIndex0
-+#define kMatchChoiceRepetitionIndex 1
++INLINE BYTE LitDecoder2DecodeNormal(ISequentialInStream *in_stream, LitDecoder2 *litDecoder2, CRangeDecoder *aRangeDecoder)
++  {
++    UINT32 aSymbol = 1;
++    UINT32 aRange = aRangeDecoder->m_Range;
++    UINT32 aCode = aRangeDecoder->m_Code;        
++    do
++    {
++      RC_GETBIT(kNumMoveBits, litDecoder2->m_Decoders[0][aSymbol], aSymbol)
++    }
++    while (aSymbol < 0x100);
++    aRangeDecoder->m_Range = aRange;
++    aRangeDecoder->m_Code = aCode;
++    return aSymbol;
++  }
 +
-+#define kNumMoveBitsForMainChoice 5
-+#define kNumMoveBitsForPosCoders 5
++INLINE BYTE LitDecoder2DecodeWithMatchByte(ISequentialInStream *in_stream, LitDecoder2 *litDecoder2, CRangeDecoder *aRangeDecoder, BYTE aMatchByte)
++  {
++    UINT32 aSymbol = 1;
++    UINT32 aRange = aRangeDecoder->m_Range;
++    UINT32 aCode = aRangeDecoder->m_Code;        
++    do
++    {
++      UINT32 aBit;
++      UINT32 aMatchBit = (aMatchByte >> 7) & 1;
++      aMatchByte <<= 1;
++      RC_GETBIT2(kNumMoveBits, litDecoder2->m_Decoders[1 + aMatchBit][aSymbol], aSymbol, 
++          aBit = 0, aBit = 1)
++      if (aMatchBit != aBit)
++      {
++        while (aSymbol < 0x100)
++        {
++          RC_GETBIT(kNumMoveBits, litDecoder2->m_Decoders[0][aSymbol], aSymbol)
++        }
++        break;
++      }
++    }
++    while (aSymbol < 0x100);
++    aRangeDecoder->m_Range = aRange;
++    aRangeDecoder->m_Code = aCode;
++    return aSymbol;
++  }
 +
-+#define kNumMoveBitsForAlignCoders 5
 +
-+#define kNumMoveBitsForPosSlotCoder 5
-+
-+#define kNumLitPosStatesBitsEncodingMax 4
-+#define kNumLitContextBitsMax 8
-+
-+
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-tools-patched/LZMA/lzmalt/lzmalt.h
---- squashfs-tools/LZMA/lzmalt/lzmalt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,16 @@
-+#ifndef __7Z_H
-+#define __7Z_H
-+
-+#if defined __cplusplus
-+extern "C"
++typedef struct LitDecoder
 +{
++  LitDecoder2 *m_Coders;
++  UINT32 m_NumPrevBits;
++  UINT32 m_NumPosBits;
++  UINT32 m_PosMask;
++} LitDecoder;
++
++
++//  LitDecoder(): m_Coders(0) {}
++//  ~LitDecoder()  { Free(); }
++
++/*
++INLINE void LitDecoderFree(LitDecoder *litDecoder)
++  { 
++    free( (char *) litDecoder->m_Coders );
++    litDecoder->m_Coders = 0;
++  }
++*/
++
++INLINE void LitDecoderCreate(LitDecoder *litDecoder, UINT32 aNumPosBits, UINT32 aNumPrevBits)
++  {
++//    LitDecoderFree(litDecoder);
++    UINT32 aNumStates;
++    litDecoder->m_NumPosBits = aNumPosBits;
++    litDecoder->m_PosMask = (1 << aNumPosBits) - 1;
++    litDecoder->m_NumPrevBits = aNumPrevBits;
++    aNumStates = 1 << (aNumPrevBits + aNumPosBits);
++    litDecoder->m_Coders = (LitDecoder2*) malloc( sizeof( LitDecoder2 ) * aNumStates );
++    //printf("malloc in LitDecoderCreate=%d\n",sizeof( LitDecoder2 ) * aNumStates);
++    if (litDecoder->m_Coders == 0)
++        printf( "Error allocating memory for LitDecoder m_Coders!\n" );
++  }
++
++INLINE void LitDecoderInit(LitDecoder *litDecoder)
++  {
++    UINT32 i;
++    UINT32 aNumStates = 1 << (litDecoder->m_NumPrevBits + litDecoder->m_NumPosBits);
++    for (i = 0; i < aNumStates; i++)
++      LitDecoder2Init(&litDecoder->m_Coders[i]);
++  }
++
++INLINE UINT32 LitDecoderGetState(LitDecoder *litDecoder, UINT32 aPos, BYTE aPrevByte)
++  { 
++    return ((aPos & litDecoder->m_PosMask) << litDecoder->m_NumPrevBits) + (aPrevByte >> (8 - litDecoder->m_NumPrevBits)); 
++  }
++
++INLINE BYTE LitDecodeNormal(ISequentialInStream *in_stream, LitDecoder *litDecoder, CRangeDecoder *aRangeDecoder, UINT32 aPos, BYTE aPrevByte)
++  { 
++    return LitDecoder2DecodeNormal(in_stream, &litDecoder->m_Coders[LitDecoderGetState(litDecoder, aPos, aPrevByte)], aRangeDecoder); 
++  }
++
++INLINE BYTE LitDecodeWithMatchByte(ISequentialInStream *in_stream, LitDecoder *litDecoder, CRangeDecoder *aRangeDecoder, UINT32 aPos, BYTE aPrevByte, BYTE aMatchByte)
++  { 
++      return LitDecoder2DecodeWithMatchByte(in_stream, &litDecoder->m_Coders[LitDecoderGetState(litDecoder, aPos, aPrevByte)], aRangeDecoder, aMatchByte); 
++  }
++
 +#endif
-+
-+int decompress_lzma_alt(unsigned char* in_data, unsigned in_size, unsigned char* out_data, unsigned out_size, int offset);
-+
-+#if defined __cplusplus
-+}
-+#endif
-+
-+#endif
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-tools-patched/LZMA/lzmalt/Makefile
---- squashfs-tools/LZMA/lzmalt/Makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/Makefile b/squashfs-tools/LZMA/lzmalt/Makefile
+new file mode 100644
+index 0000000..7e77728
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/Makefile
 @@ -0,0 +1,10 @@
 +INCLUDEDIR = .
 +
@@ -37210,9 +37173,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-to
 +
 +clean :
 +	rm -f *.o
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-tools-patched/LZMA/lzmalt/Portable.h
---- squashfs-tools/LZMA/lzmalt/Portable.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/Portable.h b/squashfs-tools/LZMA/lzmalt/Portable.h
+new file mode 100644
+index 0000000..698f30b
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/Portable.h
 @@ -0,0 +1,59 @@
 +#ifndef __PORTABLE_H
 +#define __PORTABLE_H
@@ -37273,9 +37238,60 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-
 +#define RETURN_IF_NOT_S_OK(x) { HRESULT __aResult_ = (x); if(__aResult_ != S_OK) return __aResult_; }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h
---- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2016-08-25 09:06:03.231530353 -0400
+diff --git a/squashfs-tools/LZMA/lzmalt/RCDefs.h b/squashfs-tools/LZMA/lzmalt/RCDefs.h
+new file mode 100644
+index 0000000..f260ab4
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/RCDefs.h
+@@ -0,0 +1,43 @@
++#ifndef __RCDEFS_H
++#define __RCDEFS_H
++
++#include "AriBitCoder.h"
++
++/*
++#define RC_INIT_VAR                            \
++  UINT32 aRange = aRangeDecoder->m_Range;      \
++  UINT32 aCode = aRangeDecoder->m_Code;        
++
++#define RC_FLUSH_VAR                          \
++  aRangeDecoder->m_Range = aRange;            \
++  aRangeDecoder->m_Code = aCode;
++*/
++
++
++#if 1
++#define RC_GETBIT2(aNumMoveBits, aProb, aModelIndex, Action0, Action1)                        \
++    {UINT32 aNewBound = (aRange >> kNumBitModelTotalBits) * aProb; \
++    if (aCode < aNewBound)                               \
++    {                                                             \
++      Action0;                                                    \
++      aRange = aNewBound;                                         \
++      aProb += (kBitModelTotal - aProb) >> aNumMoveBits;          \
++      aModelIndex <<= 1;                                          \
++    }                                                             \
++    else                                                          \
++    {                                                             \
++      Action1;                                                    \
++      aRange -= aNewBound;                                        \
++      aCode -= aNewBound;                                          \
++      aProb -= (aProb) >> aNumMoveBits;                           \
++      aModelIndex = (aModelIndex << 1) + 1;                       \
++    }}                                                             \
++    if (aRange < kTopValue)               \
++    {                                                              \
++      aCode = (aCode << 8) | InStreamReadByte(in_stream);   \
++      aRange <<= 8; }
++
++#define RC_GETBIT(aNumMoveBits, aProb, aModelIndex) RC_GETBIT2(aNumMoveBits, aProb, aModelIndex, ; , ;)               
++#endif
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmalt/RangeCoder.h b/squashfs-tools/LZMA/lzmalt/RangeCoder.h
+new file mode 100644
+index 0000000..ae6f974
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/RangeCoder.h
 @@ -0,0 +1,56 @@
 +#ifndef __COMPRESSION_RANGECODER_H
 +#define __COMPRESSION_RANGECODER_H
@@ -37333,56 +37349,91 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashf
 +  }
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-tools-patched/LZMA/lzmalt/RCDefs.h
---- squashfs-tools/LZMA/lzmalt/RCDefs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,43 @@
-+#ifndef __RCDEFS_H
-+#define __RCDEFS_H
+diff --git a/squashfs-tools/LZMA/lzmalt/WindowOut.h b/squashfs-tools/LZMA/lzmalt/WindowOut.h
+new file mode 100644
+index 0000000..5cb21f8
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/WindowOut.h
+@@ -0,0 +1,52 @@
++#ifndef __STREAM_WINDOWOUT_H
++#define __STREAM_WINDOWOUT_H
 +
-+#include "AriBitCoder.h"
++#include "IInOutStreams.h"
 +
-+/*
-+#define RC_INIT_VAR                            \
-+  UINT32 aRange = aRangeDecoder->m_Range;      \
-+  UINT32 aCode = aRangeDecoder->m_Code;        
++typedef struct WindowOut
++{
++  BYTE  *Buffer;
++  UINT32 Pos;
++} WindowOut;
 +
-+#define RC_FLUSH_VAR                          \
-+  aRangeDecoder->m_Range = aRange;            \
-+  aRangeDecoder->m_Code = aCode;
-+*/
++extern WindowOut out_window;
++
++#define OutWindowInit() \
++  { \
++    out_window.Buffer = (BYTE *) out_stream.data; \
++    out_window.Pos = 0; \
++  }
++
++#define OutWindowFlush() \
++  { \
++    OutStreamSizeSet( out_window.Pos ); \
++  } 
++
++// BRCM modification 
++INLINE void OutWindowCopyBackBlock(UINT32 aDistance, UINT32 aLen)
++  {
++    BYTE   *p = out_window.Buffer + out_window.Pos;
++    UINT32  i;
++    aDistance++;
++    for(i = 0; i < aLen; i++)
++      /*
++       * CJH: The freddy77 patch to prevent segfaults in 64 bit.
++       *      http://www.neufbox4.org/forum/viewtopic.php?pid=11019
++       */
++      //p[i] = p[i - aDistance];
++      p[i] = *(p+i-aDistance);
++    out_window.Pos += aLen;
++  }
 +
 +
-+#if 1
-+#define RC_GETBIT2(aNumMoveBits, aProb, aModelIndex, Action0, Action1)                        \
-+    {UINT32 aNewBound = (aRange >> kNumBitModelTotalBits) * aProb; \
-+    if (aCode < aNewBound)                               \
-+    {                                                             \
-+      Action0;                                                    \
-+      aRange = aNewBound;                                         \
-+      aProb += (kBitModelTotal - aProb) >> aNumMoveBits;          \
-+      aModelIndex <<= 1;                                          \
-+    }                                                             \
-+    else                                                          \
-+    {                                                             \
-+      Action1;                                                    \
-+      aRange -= aNewBound;                                        \
-+      aCode -= aNewBound;                                          \
-+      aProb -= (aProb) >> aNumMoveBits;                           \
-+      aModelIndex = (aModelIndex << 1) + 1;                       \
-+    }}                                                             \
-+    if (aRange < kTopValue)               \
-+    {                                                              \
-+      aCode = (aCode << 8) | InStreamReadByte(in_stream);   \
-+      aRange <<= 8; }
++#define OutWindowPutOneByte(aByte) \
++  { \
++    out_window.Buffer[out_window.Pos++] = aByte; \
++  } 
 +
-+#define RC_GETBIT(aNumMoveBits, aProb, aModelIndex) RC_GETBIT2(aNumMoveBits, aProb, aModelIndex, ; , ;)               
++#define OutWindowGetOneByte(anIndex) \
++     (out_window.Buffer[out_window.Pos + anIndex])
++
++
++
++#endif
+diff --git a/squashfs-tools/LZMA/lzmalt/lzmalt.h b/squashfs-tools/LZMA/lzmalt/lzmalt.h
+new file mode 100644
+index 0000000..de5cb5e
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/lzmalt.h
+@@ -0,0 +1,16 @@
++#ifndef __7Z_H
++#define __7Z_H
++
++#if defined __cplusplus
++extern "C"
++{
++#endif
++
++int decompress_lzma_alt(unsigned char* in_data, unsigned in_size, unsigned char* out_data, unsigned out_size, int offset);
++
++#if defined __cplusplus
++}
 +#endif
 +
 +#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h
---- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2016-08-25 09:06:03.231530353 -0400
++
+diff --git a/squashfs-tools/LZMA/lzmalt/vxTypesOld.h b/squashfs-tools/LZMA/lzmalt/vxTypesOld.h
+new file mode 100644
+index 0000000..7ee57bf
+--- /dev/null
++++ b/squashfs-tools/LZMA/lzmalt/vxTypesOld.h
 @@ -0,0 +1,289 @@
 +/* vxTypesOld.h - old VxWorks type definition header */
 +
@@ -37673,65 +37724,321 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashf
 +#endif
 +
 +#endif /* __INCvxTypesOldh */
-diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs-tools-patched/LZMA/lzmalt/WindowOut.h
---- squashfs-tools/LZMA/lzmalt/WindowOut.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2016-08-25 09:06:03.231530353 -0400
-@@ -0,0 +1,52 @@
-+#ifndef __STREAM_WINDOWOUT_H
-+#define __STREAM_WINDOWOUT_H
+diff --git a/squashfs-tools/Makefile b/squashfs-tools/Makefile
+index 46c0772..b6c1c55 100644
+--- a/squashfs-tools/Makefile
++++ b/squashfs-tools/Makefile
+@@ -30,7 +30,7 @@ GZIP_SUPPORT = 1
+ # To build install the library and uncomment
+ # the XZ_SUPPORT line below.
+ #
+-#XZ_SUPPORT = 1
++XZ_SUPPORT = 1
+ 
+ 
+ ############ Building LZO support ##############
+@@ -44,7 +44,7 @@ GZIP_SUPPORT = 1
+ # To build install the library and uncomment
+ # the XZ_SUPPORT line below.
+ #
+-#LZO_SUPPORT = 1
++LZO_SUPPORT = 1
+ 
+ 
+ ########### Building LZ4 support #############
+@@ -141,8 +141,13 @@ REPRODUCIBLE_DEFAULT = 1
+ # and uncomment the LZMA_SUPPORT line below.
+ #
+ #LZMA_XZ_SUPPORT = 1
+-#LZMA_SUPPORT = 1
+-#LZMA_DIR = ../../../../LZMA/lzma465
++LZMA_SUPPORT = 1
++# CJH: Added LZMA_BASE_DIR
++LZMA_BASE_DIR = ./LZMA
++LZMA_DIR = $(LZMA_BASE_DIR)/lzma465
++# CJH: Added these too...
++LZMA_ALT_DIR = $(LZMA_BASE_DIR)/lzmalt
++LZMA_ADAPT_DIR = $(LZMA_BASE_DIR)/lzmadaptive/C/7zip/Compress/LZMA_Lib
+ 
+ ###############################################
+ #        End of BUILD options section         #
+@@ -158,10 +163,11 @@ MKSQUASHFS_OBJS = mksquashfs.o read_fs.o action.o swap.o pseudo.o compressor.o \
+ UNSQUASHFS_OBJS = unsquashfs.o unsquash-1.o unsquash-2.o unsquash-3.o \
+ 	unsquash-4.o unsquash-123.o unsquash-34.o swap.o compressor.o unsquashfs_info.o
+ 
+-CFLAGS ?= -O2
++# CJH: Added -g, -Werror and -DSQUASHFS_TRACE
++CFLAGS ?= -g -O2
+ CFLAGS += $(EXTRA_CFLAGS) $(INCLUDEDIR) -D_FILE_OFFSET_BITS=64 \
+ 	-D_LARGEFILE_SOURCE -D_GNU_SOURCE -DCOMP_DEFAULT=\"$(COMP_DEFAULT)\" \
+-	-Wall
++	-Wall -Werror #-DSQUASHFS_TRACE
+ 
+ LIBS = -lpthread -lm
+ ifeq ($(GZIP_SUPPORT),1)
+@@ -173,13 +179,18 @@ COMPRESSORS += gzip
+ endif
+ 
+ ifeq ($(LZMA_SUPPORT),1)
++# CJH: Added -llzmalib
++LIBS += -L$(LZMA_ADAPT_DIR) -llzmalib 
+ LZMA_OBJS = $(LZMA_DIR)/C/Alloc.o $(LZMA_DIR)/C/LzFind.o \
+ 	$(LZMA_DIR)/C/LzmaDec.o $(LZMA_DIR)/C/LzmaEnc.o $(LZMA_DIR)/C/LzmaLib.o
+-INCLUDEDIR += -I$(LZMA_DIR)/C
++# CJH: Added LZMA variant directories
++INCLUDEDIR += -I$(LZMA_DIR)/C -I$(LZMA_ALT_DIR) -I$(LZMA_ADAPT_DIR)
+ CFLAGS += -DLZMA_SUPPORT
+ MKSQUASHFS_OBJS += lzma_wrapper.o $(LZMA_OBJS)
+ UNSQUASHFS_OBJS += lzma_wrapper.o $(LZMA_OBJS)
+ COMPRESSORS += lzma
++# CJH: Added LZMA_EXTRA_OBJS
++LZMA_EXTRA_OBJS = $(LZMA_ALT_DIR)/*.o
+ endif
+ 
+ ifeq ($(LZMA_XZ_SUPPORT),1)
+@@ -278,10 +289,12 @@ $(error "COMP_DEFAULT is set to ${COMP_DEFAULT}, which  isn't selected to be \
+ endif
+ 
+ .PHONY: all
+-all: mksquashfs unsquashfs
++# CJH: Made sasquatch the default target
++all: sasquatch 
+ 
++# CJH: Added LZMA_EXTRA_OBJS
+ mksquashfs: $(MKSQUASHFS_OBJS)
+-	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(MKSQUASHFS_OBJS) $(LIBS) -o $@
++	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LZMA_EXTRA_OBJS) $(MKSQUASHFS_OBJS) $(LIBS) -o $@
+ 
+ mksquashfs.o: Makefile mksquashfs.c squashfs_fs.h squashfs_swap.h mksquashfs.h \
+ 	sort.h pseudo.h compressor.h xattr.h action.h error.h progressbar.h \
+@@ -321,7 +334,8 @@ caches-queues-lists.o: caches-queues-lists.c error.h caches-queues-lists.h
+ 
+ gzip_wrapper.o: gzip_wrapper.c squashfs_fs.h gzip_wrapper.h compressor.h
+ 
+-lzma_wrapper.o: lzma_wrapper.c compressor.h squashfs_fs.h
++# CJH: Added lzmalt, lzmadaptive
++lzma_wrapper.o: lzma_wrapper.c compressor.h squashfs_fs.h lzmalt lzmadaptive
+ 
+ lzma_xz_wrapper.o: lzma_xz_wrapper.c compressor.h squashfs_fs.h
+ 
+@@ -331,8 +345,13 @@ lz4_wrapper.o: lz4_wrapper.c squashfs_fs.h lz4_wrapper.h compressor.h
+ 
+ xz_wrapper.o: xz_wrapper.c squashfs_fs.h xz_wrapper.h compressor.h
+ 
++# CJH: Added LZMA_EXTRA_OBJS
+ unsquashfs: $(UNSQUASHFS_OBJS)
+-	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(UNSQUASHFS_OBJS) $(LIBS) -o $@
++	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(UNSQUASHFS_OBJS) $(LZMA_EXTRA_OBJS) $(LIBS) -o $@
 +
-+#include "IInOutStreams.h"
++# CJH: Added sasquatch target
++sasquatch: $(UNSQUASHFS_OBJS)
++	$(CXX) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LZMA_EXTRA_OBJS) $(UNSQUASHFS_OBJS) $(LIBS) -o $@
+ 
+ unsquashfs.o: unsquashfs.h unsquashfs.c squashfs_fs.h squashfs_swap.h \
+ 	squashfs_compat.h xattr.h read_fs.h compressor.h
+@@ -354,12 +373,22 @@ unsquashfs_xattr.o: unsquashfs_xattr.c unsquashfs.h squashfs_fs.h xattr.h
+ 
+ unsquashfs_info.o: unsquashfs.h squashfs_fs.h
+ 
++# CJH: Added lzmalt, lzmadaptive
++.PHONY: lzmalt lzmadaptive
++lzmalt:
++	make -C $(LZMA_ALT_DIR)
++lzmadaptive:
++	make -C $(LZMA_ADAPT_DIR)
 +
-+typedef struct WindowOut
++# CJH: Added lzmalt, lzmadaptive
+ .PHONY: clean
+ clean:
+-	-rm -f *.o mksquashfs unsquashfs
++	-rm -f *.o $(LZMA_OBJS) mksquashfs unsquashfs sasquatch
++	make -C $(LZMA_ADAPT_DIR) clean
++	make -C $(LZMA_ALT_DIR) clean
+ 
++# CJH: Added cp sasquatch
+ .PHONY: install
+-install: mksquashfs unsquashfs
++install: sasquatch
+ 	mkdir -p $(INSTALL_DIR)
+-	cp mksquashfs $(INSTALL_DIR)
+-	cp unsquashfs $(INSTALL_DIR)
++	cp sasquatch $(INSTALL_DIR)
+diff --git a/squashfs-tools/README.md b/squashfs-tools/README.md
+new file mode 100644
+index 0000000..335c984
+--- /dev/null
++++ b/squashfs-tools/README.md
+@@ -0,0 +1,2 @@
++This is the raw, patched source code for squashfs-tools. It is included in this repository for documentation and administrative purposes only. Any bugs or patches not directly related to the modifications made by the sasquatch patches should be reported to the squashfs-tools project.
++
+diff --git a/squashfs-tools/compressor.c b/squashfs-tools/compressor.c
+index 02b5e90..19d135e 100644
+--- a/squashfs-tools/compressor.c
++++ b/squashfs-tools/compressor.c
+@@ -25,6 +25,9 @@
+ #include "compressor.h"
+ #include "squashfs_fs.h"
+ 
++// CJH: Added these includes
++#include "error.h"
++
+ #ifndef GZIP_SUPPORT
+ static struct compressor gzip_comp_ops =  {
+ 	ZLIB_COMPRESSION, "gzip"
+@@ -77,10 +80,17 @@ static struct compressor unknown_comp_ops = {
+ 	0, "unknown"
+ };
+ 
++extern struct compressor lzma_alt_comp_ops;
++extern struct compressor lzma_wrt_comp_ops;
++extern struct compressor lzma_adaptive_comp_ops;
+ 
+ struct compressor *compressor[] = {
+ 	&gzip_comp_ops,
+ 	&lzma_comp_ops,
++    // CJH: Added additional LZMA decompressors. Order is intentional.
++    &lzma_adaptive_comp_ops,
++    &lzma_alt_comp_ops,
++    &lzma_wrt_comp_ops,
+ 	&lzo_comp_ops,
+ 	&lz4_comp_ops,
+ 	&xz_comp_ops,
+@@ -89,6 +99,19 @@ struct compressor *compressor[] = {
+ };
+ 
+ 
++int lookup_compressor_index(char *name)
 +{
-+  BYTE  *Buffer;
-+  UINT32 Pos;
-+} WindowOut;
++    int i;
 +
-+extern WindowOut out_window;
++    for(i = 0; compressor[i]->id; i++)
++    {
++        if(strcmp(name, compressor[i]->name) == 0)
++            return i;
++    }
 +
-+#define OutWindowInit() \
-+  { \
-+    out_window.Buffer = (BYTE *) out_stream.data; \
-+    out_window.Pos = 0; \
-+  }
++    return -1;
++}
 +
-+#define OutWindowFlush() \
-+  { \
-+    OutStreamSizeSet( out_window.Pos ); \
-+  } 
+ struct compressor *lookup_compressor(char *name)
+ {
+ 	int i;
+@@ -143,3 +166,67 @@ void display_compressor_usage(char *def_comp)
+ 					compressor[i]->name, str);
+ 		}
+ }
 +
-+// BRCM modification 
-+INLINE void OutWindowCopyBackBlock(UINT32 aDistance, UINT32 aLen)
-+  {
-+    BYTE   *p = out_window.Buffer + out_window.Pos;
-+    UINT32  i;
-+    aDistance++;
-+    for(i = 0; i < aLen; i++)
-+      /*
-+       * CJH: The freddy77 patch to prevent segfaults in 64 bit.
-+       *      http://www.neufbox4.org/forum/viewtopic.php?pid=11019
-+       */
-+      //p[i] = p[i - aDistance];
-+      p[i] = *(p+i-aDistance);
-+    out_window.Pos += aLen;
-+  }
++// CJH: calls the currently selected decompressor, unless that fails, then tries the other decompressors
++int detected_compressor_index = 0;
++int compressor_uncompress(struct compressor *comp, void *dest, void *src, int size, int block_size, int *error)
++{
++    int i = 0, retval = -1, default_compressor_id = -1;
 +
++    if(detected_compressor_index)
++    {
++        retval = compressor[detected_compressor_index]->uncompress(dest, src, size, block_size, error);
++    }
 +
-+#define OutWindowPutOneByte(aByte) \
-+  { \
-+    out_window.Buffer[out_window.Pos++] = aByte; \
-+  } 
++    if(retval < 1 && comp->uncompress)
++    {
++        if(!detected_compressor_index) ERROR("Trying to decompress using default %s decompressor...\n", comp->name);
++        
++        retval = comp->uncompress(dest, src, size, block_size, error);
++        
++        if(!detected_compressor_index)
++        {
++            if(retval > 0)
++            {
++                ERROR("Successfully decompressed with default %s decompressor\n", comp->name);
++                detected_compressor_index = lookup_compressor_index(comp->name);
++            }
++            else
++            {
++                TRACE("Default %s decompressor failed! [%d %d]\n", comp->name, retval, *error);
++            }
++        }
++    }
 +
-+#define OutWindowGetOneByte(anIndex) \
-+     (out_window.Buffer[out_window.Pos + anIndex])
++    if(retval < 1)
++    {
++        default_compressor_id = comp->id;
 +
++        for(i=0; compressor[i]->id; i++)
++        {
++            comp = compressor[i];
++            
++            if(comp->id != default_compressor_id && 
++               comp->id != compressor[detected_compressor_index]->id && 
++               comp->uncompress)
++            {
++                ERROR("Trying to decompress with %s...\n", comp->name);
++                retval = comp->uncompress(dest, src, size, block_size, error);
++                if(retval > 0)
++                {
++                    //TRACE("%s decompressor succeeded!\n", comp->name);
++                    ERROR("Detected %s compression\n", comp->name);
++                    detected_compressor_index = i;
++                    break;
++                }
++                else
++                {
++                    TRACE("%s decompressor failed! [%d %d]\n", comp->name, retval, *error);
++                }
++            }
++        }
++    }
 +
++    return retval;
++}
 +
-+#endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-patched/lzma_wrapper.c
---- squashfs-tools/lzma_wrapper.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/lzma_wrapper.c	2016-08-25 09:06:03.223530354 -0400
+diff --git a/squashfs-tools/compressor.h b/squashfs-tools/compressor.h
+index 4679d91..6a44d27 100644
+--- a/squashfs-tools/compressor.h
++++ b/squashfs-tools/compressor.h
+@@ -59,11 +59,14 @@ static inline int compressor_compress(struct compressor *comp, void *strm,
+ }
+ 
+ 
++/* CJH: Needed more logic for compression auto-detection, no longer inlined
+ static inline int compressor_uncompress(struct compressor *comp, void *dest,
+ 	void *src, int size, int block_size, int *error)
+ {
+ 	return comp->uncompress(dest, src, size, block_size, error);
+ }
++*/
++int compressor_uncompress(struct compressor *comp, void *dest, void *src, int size, int block_size, int *error);
+ 
+ 
+ /*
+diff --git a/squashfs-tools/error.h b/squashfs-tools/error.h
+index d7cd91a..0e600d6 100644
+--- a/squashfs-tools/error.h
++++ b/squashfs-tools/error.h
+@@ -30,14 +30,18 @@ extern void prep_exit();
+ extern void progressbar_error(char *fmt, ...);
+ extern void progressbar_info(char *fmt, ...);
+ 
+-#ifdef SQUASHFS_TRACE
++// CJH: Updated so that TRACE prints if -verbose is specified on the command line
++extern int verbose;
++//#ifdef SQUASHFS_TRACE
+ #define TRACE(s, args...) \
+ 		do { \
+-			progressbar_info("squashfs: "s, ## args);\
++			if(verbose) progressbar_info("squashfs: "s, ## args);\
+ 		} while(0)
++/*
+ #else
+ #define TRACE(s, args...)
+ #endif
++*/
+ 
+ #define INFO(s, args...) \
+ 		do {\
+diff --git a/squashfs-tools/lzma_wrapper.c b/squashfs-tools/lzma_wrapper.c
+index 8d64e3d..d1e6c2b 100644
+--- a/squashfs-tools/lzma_wrapper.c
++++ b/squashfs-tools/lzma_wrapper.c
 @@ -27,14 +27,21 @@
  #include "squashfs_fs.h"
  #include "compressor.h"
@@ -37756,7 +38063,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
  	int res;
  
  	res = LzmaCompress(dest + LZMA_HEADER_SIZE, &outlen, src, size, dest,
-@@ -78,8 +85,8 @@
+@@ -78,8 +85,8 @@ static int lzma_compress(void *strm, void *dest, void *src, int size, int block_
  	return outlen + LZMA_HEADER_SIZE;
  }
  
@@ -37767,7 +38074,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
  	int *error)
  {
  	unsigned char *s = src;
-@@ -91,13 +98,23 @@
+@@ -91,13 +98,23 @@ static int lzma_uncompress(void *dest, void *src, int size, int outsize,
  		(s[LZMA_PROPS_SIZE + 2] << 16) |
  		(s[LZMA_PROPS_SIZE + 3] << 24);
  
@@ -37795,7 +38102,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
  	
  	if(res == SZ_OK)
  		return outlen;
-@@ -107,11 +124,242 @@
+@@ -107,11 +124,242 @@ static int lzma_uncompress(void *dest, void *src, int size, int outsize,
  	}
  }
  
@@ -38039,7 +38346,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
  	.options = NULL,
  	.usage = NULL,
  	.id = LZMA_COMPRESSION,
-@@ -119,3 +367,36 @@
+@@ -119,3 +367,36 @@ struct compressor lzma_comp_ops = {
  	.supported = 1
  };
  
@@ -38076,148 +38383,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
 +	.supported = 1
 +};
 +
-diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/Makefile
---- squashfs-tools/Makefile	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/Makefile	2016-08-25 09:06:03.223530354 -0400
-@@ -26,7 +26,7 @@
- # To build using XZ Utils liblzma - install the library and uncomment
- # the XZ_SUPPORT line below.
- #
--#XZ_SUPPORT = 1
-+XZ_SUPPORT = 1
- 
- 
- ############ Building LZO support ##############
-@@ -37,7 +37,7 @@
- # LZO_SUPPORT line below. If needed, uncomment and set LZO_DIR to the
- # installation prefix.
- #
--#LZO_SUPPORT = 1
-+LZO_SUPPORT = 1
- #LZO_DIR = /usr/local
- 
- 
-@@ -72,8 +72,13 @@
- # and uncomment the LZMA_SUPPORT line below.
- #
- #LZMA_XZ_SUPPORT = 1
--#LZMA_SUPPORT = 1
--#LZMA_DIR = ../../../../LZMA/lzma465
-+LZMA_SUPPORT = 1
-+# CJH: Added LZMA_BASE_DIR
-+LZMA_BASE_DIR = ./LZMA
-+LZMA_DIR = $(LZMA_BASE_DIR)/lzma465
-+# CJH: Added these too...
-+LZMA_ALT_DIR = $(LZMA_BASE_DIR)/lzmalt
-+LZMA_ADAPT_DIR = $(LZMA_BASE_DIR)/lzmadaptive/C/7zip/Compress/LZMA_Lib
- 
- ######## Specifying default compression ########
- #
-@@ -117,10 +122,11 @@
- UNSQUASHFS_OBJS = unsquashfs.o unsquash-1.o unsquash-2.o unsquash-3.o \
- 	unsquash-4.o swap.o compressor.o unsquashfs_info.o
- 
--CFLAGS ?= -O2
-+# CJH: Added -g, -Werror and -DSQUASHFS_TRACE
-+CFLAGS ?= -g -O2
- CFLAGS += $(EXTRA_CFLAGS) $(INCLUDEDIR) -D_FILE_OFFSET_BITS=64 \
- 	-D_LARGEFILE_SOURCE -D_GNU_SOURCE -DCOMP_DEFAULT=\"$(COMP_DEFAULT)\" \
--	-Wall
-+	-Wall -Werror #-DSQUASHFS_TRACE
- 
- LIBS = -lpthread -lm
- ifeq ($(GZIP_SUPPORT),1)
-@@ -132,13 +138,18 @@
- endif
- 
- ifeq ($(LZMA_SUPPORT),1)
-+# CJH: Added -llzmalib
-+LIBS += -L$(LZMA_ADAPT_DIR) -llzmalib 
- LZMA_OBJS = $(LZMA_DIR)/C/Alloc.o $(LZMA_DIR)/C/LzFind.o \
- 	$(LZMA_DIR)/C/LzmaDec.o $(LZMA_DIR)/C/LzmaEnc.o $(LZMA_DIR)/C/LzmaLib.o
--INCLUDEDIR += -I$(LZMA_DIR)/C
-+# CJH: Added LZMA variant directories
-+INCLUDEDIR += -I$(LZMA_DIR)/C -I$(LZMA_ALT_DIR) -I$(LZMA_ADAPT_DIR)
- CFLAGS += -DLZMA_SUPPORT
- MKSQUASHFS_OBJS += lzma_wrapper.o $(LZMA_OBJS)
- UNSQUASHFS_OBJS += lzma_wrapper.o $(LZMA_OBJS)
- COMPRESSORS += lzma
-+# CJH: Added LZMA_EXTRA_OBJS
-+LZMA_EXTRA_OBJS = $(LZMA_ALT_DIR)/*.o
- endif
- 
- ifeq ($(LZMA_XZ_SUPPORT),1)
-@@ -222,10 +233,12 @@
- endif
- 
- .PHONY: all
--all: mksquashfs unsquashfs
-+# CJH: Made sasquatch the default target
-+all: sasquatch 
- 
-+# CJH: Added LZMA_EXTRA_OBJS
- mksquashfs: $(MKSQUASHFS_OBJS)
--	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(MKSQUASHFS_OBJS) $(LIBS) -o $@
-+	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LZMA_EXTRA_OBJS) $(MKSQUASHFS_OBJS) $(LIBS) -o $@
- 
- mksquashfs.o: Makefile mksquashfs.c squashfs_fs.h squashfs_swap.h mksquashfs.h \
- 	sort.h pseudo.h compressor.h xattr.h action.h error.h progressbar.h \
-@@ -265,7 +278,8 @@
- 
- gzip_wrapper.o: gzip_wrapper.c squashfs_fs.h gzip_wrapper.h compressor.h
- 
--lzma_wrapper.o: lzma_wrapper.c compressor.h squashfs_fs.h
-+# CJH: Added lzmalt, lzmadaptive
-+lzma_wrapper.o: lzma_wrapper.c compressor.h squashfs_fs.h lzmalt lzmadaptive
- 
- lzma_xz_wrapper.o: lzma_xz_wrapper.c compressor.h squashfs_fs.h
- 
-@@ -275,8 +289,13 @@
- 
- xz_wrapper.o: xz_wrapper.c squashfs_fs.h xz_wrapper.h compressor.h
- 
-+# CJH: Added LZMA_EXTRA_OBJS
- unsquashfs: $(UNSQUASHFS_OBJS)
--	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(UNSQUASHFS_OBJS) $(LIBS) -o $@
-+	$(CC) $(LDFLAGS) $(EXTRA_LDFLAGS) $(UNSQUASHFS_OBJS) $(LZMA_EXTRA_OBJS) $(LIBS) -o $@
-+
-+# CJH: Added sasquatch target
-+sasquatch: $(UNSQUASHFS_OBJS)
-+	$(CXX) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LZMA_EXTRA_OBJS) $(UNSQUASHFS_OBJS) $(LIBS) -o $@
- 
- unsquashfs.o: unsquashfs.h unsquashfs.c squashfs_fs.h squashfs_swap.h \
- 	squashfs_compat.h xattr.h read_fs.h compressor.h
-@@ -294,12 +313,22 @@
- 
- unsquashfs_info.o: unsquashfs.h squashfs_fs.h
- 
-+# CJH: Added lzmalt, lzmadaptive
-+.PHONY: lzmalt lzmadaptive
-+lzmalt:
-+	make -C $(LZMA_ALT_DIR)
-+lzmadaptive:
-+	make -C $(LZMA_ADAPT_DIR)
-+
-+# CJH: Added lzmalt, lzmadaptive
- .PHONY: clean
- clean:
--	-rm -f *.o mksquashfs unsquashfs
-+	-rm -f *.o $(LZMA_OBJS) mksquashfs unsquashfs sasquatch
-+	make -C $(LZMA_ADAPT_DIR) clean
-+	make -C $(LZMA_ALT_DIR) clean
- 
-+# CJH: Added cp sasquatch
- .PHONY: install
--install: mksquashfs unsquashfs
-+install: sasquatch
- 	mkdir -p $(INSTALL_DIR)
--	cp mksquashfs $(INSTALL_DIR)
--	cp unsquashfs $(INSTALL_DIR)
-+	cp sasquatch $(INSTALL_DIR)
-diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-tools-patched/process_fragments.c
---- squashfs-tools/process_fragments.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/process_fragments.c	2016-08-25 09:06:03.223530354 -0400
-@@ -192,9 +192,10 @@
+diff --git a/squashfs-tools/process_fragments.c b/squashfs-tools/process_fragments.c
+index e3dc7c9..5b927f8 100644
+--- a/squashfs-tools/process_fragments.c
++++ b/squashfs-tools/process_fragments.c
+@@ -193,9 +193,10 @@ again:
  
  		res = compressor_uncompress(comp, buffer->data, data, size,
  			block_size, &error);
@@ -38231,10 +38401,11 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-too
  	} else if(compressed_buffer)
  		memcpy(buffer->data, compressed_buffer->data, size);
  	else {
-diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched/read_fs.c
---- squashfs-tools/read_fs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/read_fs.c	2016-08-25 09:06:03.231530353 -0400
-@@ -87,8 +87,9 @@
+diff --git a/squashfs-tools/read_fs.c b/squashfs-tools/read_fs.c
+index 0730e8c..3de5c85 100644
+--- a/squashfs-tools/read_fs.c
++++ b/squashfs-tools/read_fs.c
+@@ -87,8 +87,9 @@ int read_block(int fd, long long start, long long *next, int expected,
  		res = compressor_uncompress(comp, block, buffer, c_byte,
  			outlen, &error);
  		if(res == -1) {
@@ -38246,23 +38417,18 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched
  			return 0;
  		}
  	} else {
-diff --strip-trailing-cr -NBbaur squashfs-tools/README.md squashfs-tools-patched/README.md
---- squashfs-tools/README.md	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/README.md	2016-08-25 09:06:03.223530354 -0400
-@@ -0,0 +1,2 @@
-+This is the raw, patched source code for squashfs-tools. It is included in this repository for documentation and administrative purposes only. Any bugs or patches not directly related to the modifications made by the sasquatch patches should be reported to the squashfs-tools project.
-+
-diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-patched/squashfs_fs.h
---- squashfs-tools/squashfs_fs.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/squashfs_fs.h	2016-08-25 09:06:03.223530354 -0400
-@@ -277,6 +277,22 @@
- #define LZO_COMPRESSION		3
+diff --git a/squashfs-tools/squashfs_fs.h b/squashfs-tools/squashfs_fs.h
+index 79dfae4..1c98895 100644
+--- a/squashfs-tools/squashfs_fs.h
++++ b/squashfs-tools/squashfs_fs.h
+@@ -285,6 +285,22 @@ typedef long long		squashfs_inode;
  #define XZ_COMPRESSION		4
  #define LZ4_COMPRESSION		5
+ #define ZSTD_COMPRESSION	6
 +// CJH: Added #defines for additional decompressors
-+#define LZMA_WRT_COMPRESSION        6
-+#define LZMA_ADAPTIVE_COMPRESSION   7
-+#define LZMA_ALT_COMPRESSION        8
++#define LZMA_WRT_COMPRESSION        7
++#define LZMA_ADAPTIVE_COMPRESSION   8
++#define LZMA_ALT_COMPRESSION        9
 +
 +// CJH: A generic super block structure used for auto-detecting endianess
 +#include <stdint.h>
@@ -38278,7 +38444,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-pat
  
  struct squashfs_super_block {
  	unsigned int		s_magic;
-@@ -488,4 +504,21 @@
+@@ -496,4 +512,21 @@ struct squashfs_xattr_table {
  	unsigned int		unused;
  };
  
@@ -38300,79 +38466,69 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-pat
 +};
 +
  #endif
-diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
---- squashfs-tools/unsquashfs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/unsquashfs.c	2016-08-25 09:06:03.223530354 -0400
-@@ -32,7 +32,8 @@
- #include "stdarg.h"
-
- #include <sys/sysinfo.h>
- #include <sys/types.h>
-+#include <sys/sysmacros.h>
- #include <sys/time.h>
- #include <sys/resource.h>
+diff --git a/squashfs-tools/unsquashfs.c b/squashfs-tools/unsquashfs.c
+index 727f1d5..a008af4 100644
+--- a/squashfs-tools/unsquashfs.c
++++ b/squashfs-tools/unsquashfs.c
+@@ -40,6 +40,8 @@
  #include <limits.h>
-@@ -44,13 +44,19 @@
- pthread_mutex_t	fragment_mutex;
+ #include <ctype.h>
+ 
++int verbose = FALSE;
++
+ struct cache *fragment_cache, *data_cache;
+ struct queue *to_reader, *to_inflate, *to_writer, *from_writer;
+ pthread_t *thread, *inflator_thread;
+@@ -47,14 +49,21 @@ pthread_mutex_t	fragment_mutex;
+ static long long start_offset = 0;
  
  /* user options that control parallelisation */
 -int processors = -1;
-+//int processors = -1;
++// int processors = -1;
 +// CJH: Temporarily set the default processor count to 1 to prevent threading bug
 +//      until a proper fix is implemented.
 +int processors = 1;
  
  struct super_block sBlk;
- squashfs_operations s_ops;
+ squashfs_operations *s_ops;
+ squashfs_operations *(*read_filesystem_tables)();
 -struct compressor *comp;
--
--int bytes = 0, swap, file_count = 0, dir_count = 0, sym_count = 0,
 +// CJH: Initialize to NULL
 +struct compressor *comp = NULL;
 +// CJH: Add override struct
 +struct override_table override = { 0 };
 +// CJH: Initialize swap to -1
+ 
+-int bytes = 0, swap, file_count = 0, dir_count = 0, sym_count = 0,
 +int bytes = 0, swap = -1, file_count = 0, dir_count = 0, sym_count = 0,
  	dev_count = 0, fifo_count = 0;
- char *inode_table = NULL, *directory_table = NULL;
  struct hash_table_entry *inode_table_hash[65536], *directory_table_hash[65536];
-@@ -701,8 +707,9 @@
+ int fd;
+@@ -714,8 +723,9 @@ int read_block(int fd, long long start, long long *next, int expected,
  			outlen, &error);
  
  		if(res == -1) {
 -			ERROR("%s uncompress failed with error code %d\n",
 -				comp->name, error);
-+            // CJH: Compression errors are displayed elsewhere
++			// CJH: Compression errors are displayed elsewhere
 +			//ERROR("%s uncompress failed with error code %d\n",
 +			//	comp->name, error);
  			goto failed;
  		}
  	} else {
-@@ -720,7 +727,10 @@
+@@ -733,7 +743,10 @@ int read_block(int fd, long long start, long long *next, int expected,
  	 * is of the expected size
  	 */
  	if(expected && expected != res)
-+    {
-+        ERROR("Decompressed size did not match the expected size! [%d != %d]\n", res, expected);
- 		return 0;
-+    }
++	{
++			ERROR("Decompressed size did not match the expected size! [%d != %d]\n", res, expected);
+ 		return FALSE;
++	}
  	else
  		return res;
  
-@@ -747,8 +757,9 @@
- 			block_size, &error);
- 
- 		if(res == -1) {
--			ERROR("%s uncompress failed with error code %d\n",
--				comp->name, error);
-+            // CJH: Compression errors are displayed elsewhere
-+			//ERROR("%s uncompress failed with error code %d\n",
-+			//	comp->name, error);
- 			goto failed;
- 		}
- 
-@@ -1622,7 +1633,7 @@
- 	dir_count ++;
+@@ -1685,7 +1698,7 @@ int dir_scan(char *parent_name, unsigned int start_block, unsigned int offset,
+ 	return scan_res;
  }
  
 -
@@ -38380,21 +38536,21 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  void squashfs_stat(char *source)
  {
  	time_t mkfs_time = (time_t) sBlk.s.mkfs_time;
-@@ -1640,9 +1651,10 @@
+@@ -1704,9 +1717,10 @@ void squashfs_stat(char *source)
  
  	printf("Creation or last append time %s", mkfs_str ? mkfs_str :
  		"failed to get time\n");
--	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n",
--		sBlk.s.bytes_used / 1024.0, sBlk.s.bytes_used /
--		(1024.0 * 1024.0));
-+    // CJH: Added bytes output
-+	printf("Filesystem size %.2f Kbytes (%.2f Mbytes) (%lld [0x%llX] bytes)\n",
-+		(sBlk.s.bytes_used / 1024.0), (sBlk.s.bytes_used / (1024.0 * 1024.0)), 
-+        sBlk.s.bytes_used, sBlk.s.bytes_used);
+-	printf("Filesystem size %llu bytes (%.2f Kbytes / %.2f Mbytes)\n",
+-		sBlk.s.bytes_used, sBlk.s.bytes_used / 1024.0,
+-		sBlk.s.bytes_used / (1024.0 * 1024.0));
++	 // CJH: Added bytes output
++ 	printf("Filesystem size %.2f Kbytes (%.2f Mbytes) (%lld [0x%llX] bytes)\n",
++ 		(sBlk.s.bytes_used / 1024.0), (sBlk.s.bytes_used / (1024.0 * 1024.0)),
++				 sBlk.s.bytes_used, sBlk.s.bytes_used);
  
  	if(sBlk.s.s_major == 4) {
  		printf("Compression %s\n", comp->name);
-@@ -1714,25 +1726,25 @@
+@@ -1788,25 +1802,25 @@ void squashfs_stat(char *source)
  		printf("Number of gids %d\n", sBlk.no_guids);
  	}
  
@@ -38428,67 +38584,67 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	}
  }
  
-@@ -1745,9 +1757,11 @@
+@@ -1819,9 +1833,11 @@ int check_compression(struct compressor *comp)
  	if(!comp->supported) {
  		ERROR("Filesystem uses %s compression, this is "
  			"unsupported by this version\n", comp->name);
 -		ERROR("Decompressors available:\n");
 -		display_compressors("", "");
--		return 0;
-+        // CJH: Try to continue anyway
-+		//ERROR("Decompressors available:\n");
-+		//display_compressors("", "");
-+		//return 0;
-+        return 1;
+-		return FALSE;
++		// CJH: Try to continue anyway
++		// ERROR("Decompressors available:\n");
++		// display_compressors("", "");
++		// return FALSE;
++		return 1;
  	}
  
  	/*
-@@ -1777,17 +1791,74 @@
+@@ -1851,24 +1867,85 @@ int read_super(char *source)
  {
  	squashfs_super_block_3 sBlk_3;
  	struct squashfs_super_block sBlk_4;
-+    // CJH: Added this structure for auto-swap detection
-+    struct squashfs_generic_super_block generic = { 0 };
++	// CJH: Added this structure for auto-swap detection
++	struct squashfs_generic_super_block generic = { 0 };
 +
-+    // CJH: Perform swap auto-detection
-+    if(swap == -1)
-+    {
-+        read_fs_bytes(fd, SQUASHFS_START, sizeof(struct squashfs_generic_super_block),
-+            &generic);
-+        /*
-+         * If the major version is greater than or less than the min/max version numbers
-+         * or if the least significant bytes of the inode count field is 0, then the
-+         * image endianess is probably opposite of the host system.
-+         *
-+         * Note that these are the only fields besides s_magic that are common among 
-+         * all versions of the SquashFS super block structures, and s_magic cannot
-+         * be relied on as it is commonly mucked with by vendors.
-+         */
-+        if(generic.s_major < SQUASHFS_MIN_VERSION ||
-+           generic.s_major > SQUASHFS_MAX_VERSION ||
-+           (generic.inodes & 0xFF) == 0)
-+        {
-+            ERROR("SquashFS version [%d.%d] / inode count [%d] suggests a SquashFS image "
-+                  "of a different endianess\n", generic.s_major, generic.s_minor, generic.inodes);
-+            swap = 1;
-+        }
-+        else
-+        {
-+            ERROR("SquashFS version [%d.%d] / inode count [%d] suggests a SquashFS image "
-+                  "of the same endianess\n", generic.s_major, generic.s_minor, generic.inodes);
-+            swap = 0;
-+        }
-+    }
-+    
-+    // CJH: Warn if SquashFS magic doesn't look correct
-+    if(generic.s_magic != SQUASHFS_MAGIC && generic.s_magic != SQUASHFS_MAGIC_SWAP)
-+    {
-+        ERROR("Non-standard SquashFS Magic: %.4s\n", (char *) &generic.s_magic);
-+    }
++	// CJH: Perform swap auto-detection
++	if(swap == -1)
++	{
++		read_fs_bytes(fd, SQUASHFS_START, sizeof(struct squashfs_generic_super_block),
++			&generic);
++		/*
++		 * If the major version is greater than or less than the min/max version numbers
++		 * or if the least significant bytes of the inode count field is 0, then the
++		 * image endianess is probably opposite of the host system.
++		 *
++		 * Note that these are the only fields besides s_magic that are common among 
++		 * all versions of the SquashFS super block structures, and s_magic cannot
++		 * be relied on as it is commonly mucked with by vendors.
++		 */
++		if(generic.s_major < SQUASHFS_MIN_VERSION ||
++		   generic.s_major > SQUASHFS_MAX_VERSION ||
++		   (generic.inodes & 0xFF) == 0)
++		{
++			ERROR("SquashFS version [%d.%d] / inode count [%d] suggests a SquashFS image "
++				  "of a different endianess\n", generic.s_major, generic.s_minor, generic.inodes);
++			swap = 1;
++		}
++		else
++		{
++			ERROR("SquashFS version [%d.%d] / inode count [%d] suggests a SquashFS image "
++				  "of the same endianess\n", generic.s_major, generic.s_minor, generic.inodes);
++			swap = 0;
++		}
++	}
++	
++	// CJH: Warn if SquashFS magic doesn't look correct
++	if(generic.s_magic != SQUASHFS_MAGIC && generic.s_magic != SQUASHFS_MAGIC_SWAP)
++	{
++			ERROR("Non-standard SquashFS Magic: %.4s\n", (char *) &generic.s_magic);
++	}
 +
-+    // CJH: Notify if endianess is different
-+    if(swap)
-+        ERROR("Reading a different endian SQUASHFS filesystem on %s\n", source);
++	// CJH: Notify if endianess is different
++	if(swap)
++			ERROR("Reading a different endian SQUASHFS filesystem on %s\n", source);
  
  	/*
  	 * Try to read a Squashfs 4 superblock
@@ -38496,78 +38652,77 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	read_fs_bytes(fd, SQUASHFS_START, sizeof(struct squashfs_super_block),
  		&sBlk_4);
 -	swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
-+	// CJH: swap detection already done generically above
-+    //swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
++ 	// CJH: swap detection already done generically above
++	// swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
  	SQUASHFS_INSWAP_SUPER_BLOCK(&sBlk_4);
  
-+    /*
-+     * CJH: Don't consider it an error if SQUASHFS_MAGIC doesn't match
++	/*
++	 * CJH: Don't consider it an error if SQUASHFS_MAGIC doesn't match
  	if(sBlk_4.s_magic == SQUASHFS_MAGIC && sBlk_4.s_major == 4 &&
  			sBlk_4.s_minor == 0) {
-+     */
++	*/
 +
-+     // CJH: Added s_major override
-+     if((sBlk_4.s_major == 4 && sBlk_4.s_minor == 0) ||
-+        (override.s_major == 4)) {
++	 // CJH: Added s_major override
++	 if((sBlk_4.s_major == 4 && sBlk_4.s_minor == 0) ||
++		(override.s_major == 4)) {
 +
-+        // CJH: Update super struct with override values
-+        if(override.s_major)
-+            sBlk_4.s_major = override.s_major;
-+        if(override.s_minor)
-+            sBlk_4.s_minor = override.s_minor;
++		// CJH: Update super struct with override values
++		if(override.s_major)
++			sBlk_4.s_major = override.s_major;
++		if(override.s_minor)
++			sBlk_4.s_minor = override.s_minor;
 +
- 		s_ops.squashfs_opendir = squashfs_opendir_4;
- 		s_ops.read_fragment = read_fragment_4;
- 		s_ops.read_fragment_table = read_fragment_table_4;
-@@ -1799,7 +1870,11 @@
+ 		read_filesystem_tables = read_filesystem_tables_4;
+ 		memcpy(&sBlk, &sBlk_4, sizeof(sBlk_4));
+ 
  		/*
  		 * Check the compression type
  		 */
-+        // CJH: Check to see if comp has alredy been defined
++		// CJH: Check to see if comp has alredy been defined
 +		if(!comp)
-+        {
++		{
  		comp = lookup_compressor_id(sBlk.s.compression);
-+        }
++		}
  		return TRUE;
  	}
  
-@@ -1813,6 +1888,9 @@
+@@ -1882,6 +1959,9 @@ int read_super(char *source)
  	/*
  	 * Check it is a SQUASHFS superblock
  	 */
 +	/*
 +	 * CJH: swap detection already done generically above
-+     *
++	 *
  	swap = 0;
  	if(sBlk_3.s_magic != SQUASHFS_MAGIC) {
  		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP) {
-@@ -1828,6 +1906,13 @@
+@@ -1897,6 +1977,13 @@ int read_super(char *source)
  			goto failed_mount;
  		}
  	}
-+    */
-+    if(swap)
-+    {
-+        squashfs_super_block_3 sblk;
-+        SQUASHFS_SWAP_SUPER_BLOCK_3(&sblk, &sBlk_3);
-+        memcpy(&sBlk_3, &sblk, sizeof(squashfs_super_block_3));
-+    }
++	*/
++	if(swap)
++	{
++		squashfs_super_block_3 sblk;
++		SQUASHFS_SWAP_SUPER_BLOCK_3(&sblk, &sBlk_3);
++		memcpy(&sBlk_3, &sblk, sizeof(squashfs_super_block_3));
++	}
  
  	sBlk.s.s_magic = sBlk_3.s_magic;
  	sBlk.s.inodes = sBlk_3.inodes;
-@@ -1850,14 +1935,22 @@
+@@ -1919,14 +2006,22 @@ int read_super(char *source)
  	sBlk.guid_start = sBlk_3.guid_start;
  	sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
  
-+    // CJH: Update super struct with override values
-+    if(override.s_major)
-+        sBlk.s.s_major = override.s_major;
-+    if(override.s_minor)
-+        sBlk.s.s_minor = override.s_minor;
++	// CJH: Update super struct with override values
++	if(override.s_major)
++		sBlk.s.s_major = override.s_major;
++	if(override.s_minor)
++		sBlk.s.s_minor = override.s_minor;
 +
  	/* Check the MAJOR & MINOR versions */
 -	if(sBlk.s.s_major == 1 || sBlk.s.s_major == 2) {
-+    // CJH: Added s_major override
++	// CJH: Added s_major override
 +	if((sBlk.s.s_major == 1 || sBlk.s.s_major == 2)) {
  		sBlk.s.bytes_used = sBlk_3.bytes_used_2;
  		sBlk.uid_start = sBlk_3.uid_start_2;
@@ -38575,150 +38730,153 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		sBlk.s.inode_table_start = sBlk_3.inode_table_start_2;
  		sBlk.s.directory_table_start = sBlk_3.directory_table_start_2;
  		
-+        // CJH: Added s_major override
++		// CJH: Added s_major override
  		if(sBlk.s.s_major == 1) {
  			sBlk.s.block_size = sBlk_3.block_size_1;
  			sBlk.s.fragment_table_start = sBlk.uid_start;
-@@ -1893,7 +1986,11 @@
+@@ -1948,7 +2043,11 @@ int read_super(char *source)
  	/*
  	 * 1.x, 2.x and 3.x filesystems use gzip compression.
  	 */
-+    // CJH: Check to see if comp has alredy been defined
-+    if(!comp)
-+    {
++	// CJH: Check to see if comp has alredy been defined
++	if(!comp)
++	{
  	comp = lookup_compressor("gzip");
-+    }
++	}
  	return TRUE;
  
  failed_mount:
-@@ -2106,11 +2203,15 @@
+@@ -2167,11 +2266,15 @@ void *inflator(void *arg)
  			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size), block_size,
  			&error);
  
-+        /* CJH: Compression errors are displayed elsewhere
++		/* CJH: Compression errors are displayed elsewhere
  		if(res == -1)
  			ERROR("%s uncompress failed with error code %d\n",
  				comp->name, error);
  		else
  			memcpy(entry->data, tmp, res);
-+        */
-+        if(res != -1)
-+            memcpy(entry->data, tmp, res);
++		*/
++		if(res != -1)
++			memcpy(entry->data, tmp, res);
  
  		/*
  		 * block has been either successfully decompressed, or an error
-@@ -2505,6 +2606,9 @@
- 	int fragment_buffer_size = FRAGMENT_BUFFER_DEFAULT;
- 	int data_buffer_size = DATA_BUFFER_DEFAULT;
+@@ -2639,6 +2742,9 @@ int main(int argc, char *argv[])
+ 	long res;
+ 	int exit_code = 0;
  
-+    // CJH: Initialize verbosity to FALSE
-+    verbose = FALSE;
++	// CJH: Initialize verbosity to FALSE
++	verbose = FALSE;
 +
  	pthread_mutex_init(&screen_mutex, NULL);
  	root_process = geteuid() == 0;
  	if(root_process)
-@@ -2611,6 +2715,83 @@
- 		} else if(strcmp(argv[i], "-regex") == 0 ||
- 				strcmp(argv[i], "-r") == 0)
- 			use_regex = TRUE;
-+        // CJH: Added -comp, -be, -le, -major, -minor options
-+        else if(strcmp(argv[i], "-c") == 0 ||
-+                strcmp(argv[i], "-comp") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -comp missing compression option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            comp = lookup_compressor(argv[i]);
-+        } else if(strcmp(argv[i], "-major") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -major missing version option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            override.s_major = atoi(argv[i]);
-+        } else if(strcmp(argv[i], "-minor") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -minor missing version option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            override.s_minor = atoi(argv[i]);
-+        } else if(strcmp(argv[i], "-lc") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -lc missing value option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            override.lc.value = atoi(argv[i]);
-+            override.lc.set = TRUE;
-+        } else if(strcmp(argv[i], "-lp") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -lp missing value option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            override.lp.value = atoi(argv[i]);
-+            override.lp.set = TRUE;
-+        } else if(strcmp(argv[i], "-pb") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -pb missing value option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            override.pb.value = atoi(argv[i]);
-+            override.pb.set = TRUE;
-+        } else if(strcmp(argv[i], "-dict") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -dict missing value option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            override.dictionary_size.value = atoi(argv[i]);
-+            override.dictionary_size.set = TRUE;
-+        } else if(strcmp(argv[i], "-lzma-offset") == 0) {
-+            if(++i == argc) {
-+                fprintf(stderr, "%s: -lzma-offset missing value option\n",
-+                    argv[0]);
-+                exit(1);
-+            }
-+            override.offset.value = atoi(argv[i]);
-+            override.offset.set = TRUE;
-+        } else if(strcmp(argv[i], "-be") == 0)
+@@ -2776,7 +2882,85 @@ int main(int argc, char *argv[])
+ 				ERROR("%s: %s missing or invalid offset size\n", argv[0], argv[i - 1]);
+ 				exit(1);
+ 			}
+-		} else
++		}
++		// CJH: Added -comp, -be, -le, -major, -minor options
++		else if(strcmp(argv[i], "-c") == 0 ||
++				strcmp(argv[i], "-comp") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -comp missing compression option\n",
++					argv[0]);
++				exit(1);
++			}
++			comp = lookup_compressor(argv[i]);
++		} else if(strcmp(argv[i], "-major") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -major missing version option\n",
++					argv[0]);
++				exit(1);
++			}
++			override.s_major = atoi(argv[i]);
++		} else if(strcmp(argv[i], "-minor") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -minor missing version option\n",
++					argv[0]);
++				exit(1);
++			}
++			override.s_minor = atoi(argv[i]);
++		} else if(strcmp(argv[i], "-lc") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -lc missing value option\n",
++					argv[0]);
++				exit(1);
++			}
++			override.lc.value = atoi(argv[i]);
++			override.lc.set = TRUE;
++		} else if(strcmp(argv[i], "-lp") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -lp missing value option\n",
++					argv[0]);
++				exit(1);
++			}
++			override.lp.value = atoi(argv[i]);
++			override.lp.set = TRUE;
++		} else if(strcmp(argv[i], "-pb") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -pb missing value option\n",
++					argv[0]);
++				exit(1);
++			}
++			override.pb.value = atoi(argv[i]);
++			override.pb.set = TRUE;
++		} else if(strcmp(argv[i], "-dict") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -dict missing value option\n",
++					argv[0]);
++				exit(1);
++			}
++			override.dictionary_size.value = atoi(argv[i]);
++			override.dictionary_size.set = TRUE;
++		} else if(strcmp(argv[i], "-lzma-offset") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -lzma-offset missing value option\n",
++					argv[0]);
++				exit(1);
++			}
++			override.offset.value = atoi(argv[i]);
++			override.offset.set = TRUE;
++		} else if(strcmp(argv[i], "-be") == 0)
 +#if __BYTE_ORDER == __BIG_ENDIAN
-+            swap = 0;
++			swap = 0;
 +#else
-+            swap = 1;
++			swap = 1;
 +#endif
-+        else if(strcmp(argv[i], "-le") == 0)
++		else if(strcmp(argv[i], "-le") == 0)
 +#if __BYTE_ORDER == __LITTLE_ENDIAN
-+            swap = 0;
++			swap = 0;
 +#else
-+            swap = 1;
++			swap = 1;
 +#endif
-+        else if(strcmp(argv[i], "-trace") == 0)
-+            verbose = TRUE;
- 		else
++		else if(strcmp(argv[i], "-trace") == 0)
++			verbose = TRUE;
++		else
  			goto options;
  	}
-@@ -2674,6 +2855,22 @@
+ 
+@@ -2859,6 +3043,22 @@ options:
  				"regular expressions\n");
  			ERROR("\t\t\t\trather than use the default shell "
  				"wildcard\n\t\t\t\texpansion (globbing)\n");
-+            // CJH: Added -comp, -be, -le, -major, -minor, -trace and lzma options help output
-+            ERROR("\n");
-+            ERROR("\t-trace\t\t\tEnable verbose trace output\n");
-+            ERROR("\t-lc <value>\t\tSet the lzma-adaptive lc parameter [0-4]\n");
-+            ERROR("\t-lp <value>\t\tSet the lzma-adaptive lp parameter [0-4]\n");
-+            ERROR("\t-pb <value>\t\tSet the lzma-adaptive pb parameter [0-8]\n");
-+            ERROR("\t-dict <value>\t\tSet the lzma-adaptive dictionary size\n");
-+            ERROR("\t-lzma-offset <value>\tSet the lzma-adaptive LZMA data offset\n");
-+            ERROR("\t-major <version>\tManually set the SquashFS major "
-+                "version number\n");
-+            ERROR("\t-minor <version>\tManually set the SquashFS minor "
-+                "version number\n");
-+            ERROR("\t-be\t\t\tTreat the filesystem as big endian\n");
-+            ERROR("\t-le\t\t\tTreat the filesystem as little endian\n");
++			// CJH: Added -comp, -be, -le, -major, -minor, -trace and lzma options help output
++			ERROR("\n");
++			ERROR("\t-trace\t\t\tEnable verbose trace output\n");
++			ERROR("\t-lc <value>\t\tSet the lzma-adaptive lc parameter [0-4]\n");
++			ERROR("\t-lp <value>\t\tSet the lzma-adaptive lp parameter [0-4]\n");
++			ERROR("\t-pb <value>\t\tSet the lzma-adaptive pb parameter [0-8]\n");
++			ERROR("\t-dict <value>\t\tSet the lzma-adaptive dictionary size\n");
++			ERROR("\t-lzma-offset <value>\tSet the lzma-adaptive LZMA data offset\n");
++			ERROR("\t-major <version>\tManually set the SquashFS major "
++				"version number\n");
++			ERROR("\t-minor <version>\tManually set the SquashFS minor "
++				"version number\n");
++			ERROR("\t-be\t\t\tTreat the filesystem as big endian\n");
++			ERROR("\t-le\t\t\tTreat the filesystem as little endian\n");
 +			ERROR("\t-c[omp] <decompressor>\tSpecify the "
 +				"decompressor to use\n");
  			ERROR("\nDecompressors available:\n");

--- a/patches/1_fix_dangling_pointer.patch
+++ b/patches/1_fix_dangling_pointer.patch
@@ -1,0 +1,77 @@
+diff --git a/squashfs-tools/LZMA/lzma465/C/LzmaEnc.c b/squashfs-tools/LZMA/lzma465/C/LzmaEnc.c
+index 3a2c9da..0307184 100644
+--- a/squashfs-tools/LZMA/lzma465/C/LzmaEnc.c
++++ b/squashfs-tools/LZMA/lzma465/C/LzmaEnc.c
+@@ -239,6 +239,14 @@ typedef struct _CSeqInStreamBuf
+   SizeT rem;
+ } CSeqInStreamBuf;
+ 
++typedef struct _CSeqOutStreamBuf
++{
++  ISeqOutStream funcTable;
++  Byte *data;
++  SizeT rem;
++  Bool overflow;
++} CSeqOutStreamBuf;
++
+ static SRes MyRead(void *pp, void *data, size_t *size)
+ {
+   size_t curSize = *size;
+@@ -354,6 +362,8 @@ typedef struct _CLzmaEnc
+   ISeqInStream *inStream;
+   CSeqInStreamBuf seqBufInStream;
+ 
++  CSeqOutStreamBuf outStreamBuf;
++
+   CSaveState saveState;
+ } CLzmaEnc;
+ 
+@@ -2101,14 +2111,6 @@ void LzmaEnc_Finish(CLzmaEncHandle pp)
+   #endif
+ }
+ 
+-typedef struct _CSeqOutStreamBuf
+-{
+-  ISeqOutStream funcTable;
+-  Byte *data;
+-  SizeT rem;
+-  Bool overflow;
+-} CSeqOutStreamBuf;
+-
+ static size_t MyWrite(void *pp, const void *data, size_t size)
+ {
+   CSeqOutStreamBuf *p = (CSeqOutStreamBuf *)pp;
+@@ -2142,12 +2144,11 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, Bool reInit,
+   CLzmaEnc *p = (CLzmaEnc *)pp;
+   UInt64 nowPos64;
+   SRes res;
+-  CSeqOutStreamBuf outStream;
+ 
+-  outStream.funcTable.Write = MyWrite;
+-  outStream.data = dest;
+-  outStream.rem = *destLen;
+-  outStream.overflow = False;
++  p->outStreamBuf.funcTable.Write = MyWrite;
++  p->outStreamBuf.data = dest;
++  p->outStreamBuf.rem = *destLen;
++  p->outStreamBuf.overflow = False;
+ 
+   p->writeEndMark = False;
+   p->finished = False;
+@@ -2158,13 +2159,13 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, Bool reInit,
+   LzmaEnc_InitPrices(p);
+   nowPos64 = p->nowPos64;
+   RangeEnc_Init(&p->rc);
+-  p->rc.outStream = &outStream.funcTable;
++  p->rc.outStream = &p->outStreamBuf.funcTable;
+ 
+   res = LzmaEnc_CodeOneBlock(p, True, desiredPackSize, *unpackSize);
+   
+   *unpackSize = (UInt32)(p->nowPos64 - nowPos64);
+-  *destLen -= outStream.rem;
+-  if (outStream.overflow)
++  *destLen -= p->outStreamBuf.rem;
++  if (p->outStreamBuf.overflow)
+     return SZ_ERROR_OUTPUT_EOF;
+ 
+   return res;


### PR DESCRIPTION
## Overview
Create a Dockerfile to enable a portable build environment, and sync patch to build with `squashfs-tools` 4.4

## Details
The Dockerfile is based on Ubuntu 24.04, and uses multiple stages to produce a minimal final product, with the final image size sitting at about 75mb.

This branch also incorporates the updates prepared by @cole-h to update to squashfs-tools 4.4 in #56.

Finally, building on newer GCC highlights a dangling pointer error in `LzmaEnc.c`:
```
LZMA/lzma465/C/LzmaEnc.c: In function ‘LzmaEnc_CodeOneMemBlock’:
LZMA/lzma465/C/LzmaEnc.c:2161:19: error: storing the address of local variable ‘outStream’ in ‘*(CLzmaEnc *)pp.rc.outStream’ [-Werror=dangling-pointer=]
 2161 |   p->rc.outStream = &outStream.funcTable;
      |   ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
LZMA/lzma465/C/LzmaEnc.c:2145:20: note: ‘outStream’ declared here
 2145 |   CSeqOutStreamBuf outStream;
      |                    ^~~~~~~~~
LZMA/lzma465/C/LzmaEnc.c:2139:45: note: ‘pp’ declared here
 2139 | SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, Bool reInit,
      |                              ~~~~~~~~~~~~~~~^~
cc1: all warnings being treated as errors
make: *** [<builtin>: LZMA/lzma465/C/LzmaEnc.o] Error 1
```

I have separated the fix for this problem into a dedicated patch file for ease of review.

I know this PR probably won't ever be merged, but sasquatch is still useful for reading vendor-specific SquashFS implementations, and until the upstream project can support these tweaks I guess this is the next best thing.