### PR TITLE
Fix XZ build when bundled LZMA header shadows liblzma

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,9 @@ tar -zxvf squashfs4.3.tar.gz
 
 # Patch, build, and install the source
 cd squashfs4.3
-patch -p0 < ../patches/patch0.txt
+for patch_file in ../patches/patch*.txt
+do
+    patch -p0 < "$patch_file"
+done
 cd squashfs-tools
 make && $SUDO make install

--- a/patches/patch0.txt
+++ b/patches/patch0.txt
@@ -1,6 +1,6 @@
 diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patched/compressor.c
---- squashfs-tools/compressor.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.c	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/compressor.c	2014-03-09 06:31:58.000000000 +0100
++++ squashfs-tools-patched/compressor.c	2023-05-23 16:19:06.321285058 +0200
 @@ -25,6 +25,9 @@
  #include "compressor.h"
  #include "squashfs_fs.h"
@@ -121,8 +121,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patc
 +}
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patched/compressor.h
---- squashfs-tools/compressor.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/compressor.h	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/compressor.h	2014-05-10 06:54:13.000000000 +0200
++++ squashfs-tools-patched/compressor.h	2023-05-23 16:19:06.321285058 +0200
 @@ -59,11 +59,14 @@
  }
  
@@ -139,15 +139,15 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patc
  
  /*
 diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
---- squashfs-tools/error.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/error.h	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/error.h	2014-05-10 06:54:13.000000000 +0200
++++ squashfs-tools-patched/error.h	2023-05-23 16:19:06.325285093 +0200
 @@ -30,14 +30,18 @@
  extern void progressbar_error(char *fmt, ...);
  extern void progressbar_info(char *fmt, ...);
  
 -#ifdef SQUASHFS_TRACE
 +// CJH: Updated so that TRACE prints if -verbose is specified on the command line
-+int verbose;
++extern int verbose;
 +//#ifdef SQUASHFS_TRACE
  #define TRACE(s, args...) \
  		do { \
@@ -163,8 +163,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/e
  #define INFO(s, args...) \
  		do {\
 diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/LICENSE
---- squashfs-tools/LICENSE	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LICENSE	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LICENSE	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LICENSE	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,339 @@
 +                    GNU GENERAL PUBLIC LICENSE
 +                       Version 2, June 1991
@@ -506,8 +506,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/L
 +library.  If this is what you want to do, use the GNU Lesser General
 +Public License instead of this License.
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-tools-patched/LZMA/lzma465/7zC.txt
---- squashfs-tools/LZMA/lzma465/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/7zC.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,194 @@
 +7z ANSI-C Decoder 4.62
 +----------------------
@@ -704,8 +704,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-to
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squashfs-tools-patched/LZMA/lzma465/7zFormat.txt
---- squashfs-tools/LZMA/lzma465/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/7zFormat.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -1179,8 +1179,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squash
 +---
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,45 @@
 +/* 7zBuf2.c -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1228,8 +1228,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs
 +  p->pos = 0;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c
---- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,36 @@
 +/* 7zBuf.c -- Byte Buffer
 +2008-03-28
@@ -1268,8 +1268,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-
 +  p->size = 0;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h
---- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,31 @@
 +/* 7zBuf.h -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1303,8 +1303,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c
---- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,35 @@
 +/* 7zCrc.c -- CRC32 calculation
 +2008-08-05
@@ -1342,8 +1342,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-
 +  return CrcUpdate(CRC_INIT_VAL, data, size) ^ 0xFFFFFFFF;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h
---- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h -- CRC32 calculation
 +2008-03-13
@@ -1370,8 +1370,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs-tools-patched/LZMA/lzma465/C/7zFile.c
---- squashfs-tools/LZMA/lzma465/C/7zFile.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zFile.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,263 @@
 +/* 7zFile.c -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1637,8 +1637,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs
 +  p->s.Write = FileOutStream_Write;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs-tools-patched/LZMA/lzma465/C/7zFile.h
---- squashfs-tools/LZMA/lzma465/C/7zFile.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zFile.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,74 @@
 +/* 7zFile.h -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1715,8 +1715,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squashfs-tools-patched/LZMA/lzma465/C/7zStream.c
---- squashfs-tools/LZMA/lzma465/C/7zStream.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zStream.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,169 @@
 +/* 7zStream.c -- 7z Stream functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -1888,8 +1888,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squash
 +  p->s.Read = SecToRead_Read;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h
---- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,7 @@
 +#define MY_VER_MAJOR 4
 +#define MY_VER_MINOR 65
@@ -1899,8 +1899,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squas
 +#define MY_COPYRIGHT ": Igor Pavlov : Public domain"
 +#define MY_VERSION_COPYRIGHT_DATE MY_VERSION " " MY_COPYRIGHT " : " MY_DATE
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-tools-patched/LZMA/lzma465/C/Alloc.c
---- squashfs-tools/LZMA/lzma465/C/Alloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Alloc.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,127 @@
 +/* Alloc.c -- Memory allocation functions
 +2008-09-24
@@ -2030,8 +2030,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-tools-patched/LZMA/lzma465/C/Alloc.h
---- squashfs-tools/LZMA/lzma465/C/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Alloc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,32 @@
 +/* Alloc.h -- Memory allocation functions
 +2008-03-13
@@ -2066,8 +2066,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,77 @@
 +/* 7zAlloc.c -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2147,8 +2147,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +  free(address);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,15 @@
 +/* 7zAlloc.h -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2166,8 +2166,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,254 @@
 +/* 7zDecode.c -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2424,8 +2424,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,13 @@
 +/* 7zDecode.h -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2441,8 +2441,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,199 @@
 +# Microsoft Developer Studio Project File - Name="7z" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -2644,8 +2644,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp
 +# End Target
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -2677,8 +2677,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw
 +###############################################################################
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,93 @@
 +/* 7zExtract.c -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2774,8 +2774,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,41 @@
 +/* 7zExtract.h -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2819,8 +2819,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,6 @@
 +/*  7zHeader.c -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2829,8 +2829,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,57 @@
 +/* 7zHeader.h -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2890,8 +2890,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,1204 @@
 +/* 7zIn.c -- 7z Input functions
 +2008-12-31 : Igor Pavlov : Public domain */
@@ -4098,8 +4098,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,41 @@
 +/* 7zIn.h -- 7z Input functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4143,8 +4143,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h
 + 
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,127 @@
 +/* 7zItem.c -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4274,8 +4274,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +  SzAr_Init(p);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,84 @@
 +/* 7zItem.h -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4362,8 +4362,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,262 @@
 +/* 7zMain.c - Test application for 7z Decoder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4628,8 +4628,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain
 +  return 1;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,33 @@
 +MY_STATIC_LINK=1
 +
@@ -4665,8 +4665,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +$(C_OBJS): ../../$(*B).c
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,61 @@
 +PROG = 7zDec
 +CXX = g++
@@ -4730,8 +4730,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +	-$(RM) $(PROG) $(OBJS)
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c
---- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,132 @@
 +/* Bcj2.c -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4866,8 +4866,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-t
 +  return (outPos == outSize) ? SZ_OK : SZ_ERROR_DATA;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h
---- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,30 @@
 +/* Bcj2.h -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4900,8 +4900,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-t
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-tools-patched/LZMA/lzma465/C/Bra86.c
---- squashfs-tools/LZMA/lzma465/C/Bra86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Bra86.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,85 @@
 +/* Bra86.c -- Converter for x86 code (BCJ)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4989,8 +4989,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-
 +  return bufferPos;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-tools-patched/LZMA/lzma465/C/Bra.c
---- squashfs-tools/LZMA/lzma465/C/Bra.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Bra.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,133 @@
 +/* Bra.c -- Converters for RISC code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5126,8 +5126,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-to
 +  return i;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-tools-patched/LZMA/lzma465/C/Bra.h
---- squashfs-tools/LZMA/lzma465/C/Bra.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Bra.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,60 @@
 +/* Bra.h -- Branch converters for executables
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5190,8 +5190,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-to
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c
---- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,67 @@
 +/* BraIA64.c -- Converter for IA-64 code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5261,8 +5261,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashf
 +  return i;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h
---- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,69 @@
 +/* CpuArch.h
 +2008-08-05
@@ -5334,8 +5334,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashf
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs-tools-patched/LZMA/lzma465/C/LzFind.c
---- squashfs-tools/LZMA/lzma465/C/LzFind.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzFind.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,751 @@
 +/* LzFind.c -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6089,8 +6089,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs
 +  }
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs-tools-patched/LZMA/lzma465/C/LzFind.h
---- squashfs-tools/LZMA/lzma465/C/LzFind.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzFind.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,107 @@
 +/* LzFind.h -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6200,8 +6200,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,793 @@
 +/* LzFindMt.c -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6997,8 +6997,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squash
 +  }
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h
---- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,97 @@
 +/* LzFindMt.h -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7098,8 +7098,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squash
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs-tools-patched/LZMA/lzma465/C/LzHash.h
---- squashfs-tools/LZMA/lzma465/C/LzHash.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzHash.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,54 @@
 +/* LzHash.h -- HASH functions for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7156,8 +7156,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,1007 @@
 +/* LzmaDec.c -- LZMA Decoder
 +2008-11-06 : Igor Pavlov : Public domain */
@@ -8167,8 +8167,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashf
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2023-05-23 16:19:06.321285058 +0200
 @@ -0,0 +1,223 @@
 +/* LzmaDec.h -- LZMA Decoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -8394,8 +8394,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashf
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,2281 @@
 +/* LzmaEnc.c -- LZMA Encoder
 +2009-02-02 : Igor Pavlov : Public domain */
@@ -10679,8 +10679,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashf
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,72 @@
 +/*  LzmaEnc.h -- LZMA Encoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10755,16 +10755,16 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashf
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,4 @@
 +EXPORTS
 +  LzmaCompress
 +  LzmaUncompress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="LzmaLib" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -10945,8 +10945,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +# End Target
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -10978,8 +10978,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +###############################################################################
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,12 @@
 +/* LzmaLibExports.c -- LZMA library DLL Entry point
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10994,8 +10994,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibEx
 +  return TRUE;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,37 @@
 +MY_STATIC_LINK=1
 +SLIB = sLZMA.lib
@@ -11035,16 +11035,16 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile 
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc
---- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,4 @@
 +#include "../../CPP/7zip/MyVersionInfo.rc"
 +
 +MY_VERSION_INFO_DLL("LZMA library", "LZMA")
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,46 @@
 +/* LzmaLib.c -- LZMA library wrapper
 +2008-08-05
@@ -11093,8 +11093,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashf
 +  return LzmaDecode(dest, destLen, src, srcLen, props, (unsigned)propsSize, LZMA_FINISH_ANY, &status, &g_Alloc);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h
---- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,135 @@
 +/* LzmaLib.h -- LZMA library interface
 +2008-08-05
@@ -11232,8 +11232,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashf
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,61 @@
 +/* Lzma86Dec.c -- LZMA + x86 (BCJ) Filter Decoder
 +2008-04-07
@@ -11297,8 +11297,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +  return SZ_OK;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,45 @@
 +/* Lzma86Dec.h -- LZMA + x86 (BCJ) Filter Decoder
 +2008-08-05
@@ -11346,8 +11346,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,113 @@
 +/* Lzma86Enc.c -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11463,8 +11463,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +  return mainResult;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,72 @@
 +/* Lzma86Enc.h -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11539,8 +11539,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,254 @@
 +/* LzmaUtil.c -- Test application for LZMA compression
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -11797,8 +11797,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,168 @@
 +# Microsoft Developer Studio Project File - Name="LzmaUtil" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -11969,8 +11969,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +# End Target
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -12002,8 +12002,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +###############################################################################
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,29 @@
 +MY_STATIC_LINK=1
 +PROG = LZMAc.exe
@@ -12035,8 +12035,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +$(C_OBJS): ../$(*B).c
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc
---- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,44 @@
 +PROG = lzma
 +CXX = g++
@@ -12083,8 +12083,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +clean:
 +	-$(RM) $(PROG) $(OBJS)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashfs-tools-patched/LZMA/lzma465/C/Threads.c
---- squashfs-tools/LZMA/lzma465/C/Threads.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Threads.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,109 @@
 +/* Threads.c -- multithreading library
 +2008-08-05
@@ -12196,8 +12196,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashf
 +}
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashfs-tools-patched/LZMA/lzma465/C/Threads.h
---- squashfs-tools/LZMA/lzma465/C/Threads.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Threads.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,68 @@
 +/* Threads.h -- multithreading library
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -12268,8 +12268,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashf
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-tools-patched/LZMA/lzma465/C/Types.h
---- squashfs-tools/LZMA/lzma465/C/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/C/Types.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,208 @@
 +/* Types.h -- Basic types
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -12480,8 +12480,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashfs-tools-patched/LZMA/lzma465/history.txt
---- squashfs-tools/LZMA/lzma465/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/history.txt	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/history.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/history.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,236 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -12720,8 +12720,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashf
 +
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-tools-patched/LZMA/lzma465/lzma.txt
---- squashfs-tools/LZMA/lzma465/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/lzma.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,594 @@
 +LZMA SDK 4.65
 +-------------
@@ -13318,8 +13318,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-t
 +http://www.7-zip.org/sdk.html
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashfs-tools-patched/LZMA/lzma465/Methods.txt
---- squashfs-tools/LZMA/lzma465/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzma465/Methods.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,137 @@
 +7-Zip method IDs (4.65)
 +-----------------------
@@ -13459,8 +13459,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashf
 +---
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt
---- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,235 @@
 +7z ANSI-C Decoder 4.23
 +----------------------
@@ -13698,8 +13698,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashf
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt
---- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -14173,8 +14173,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt sq
 +---
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,70 @@
 +/* 7zAlloc.c */
 +
@@ -14247,8 +14247,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  free(address);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,20 @@
 +/* 7zAlloc.h */
 +
@@ -14271,8 +14271,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,29 @@
 +/* 7zBuffer.c */
 +
@@ -14304,8 +14304,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  buffer->Capacity = 0;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,19 @@
 +/* 7zBuffer.h */
 +
@@ -14327,8 +14327,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="7z_C" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -14509,8 +14509,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +# End Target
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -14542,8 +14542,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +###############################################################################
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,76 @@
 +/* 7zCrc.c */
 +
@@ -14622,8 +14622,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  return (CrcCalculateDigest(data, size) == digest);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h */
 +
@@ -14650,8 +14650,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,150 @@
 +/* 7zDecode.c */
 +
@@ -14804,8 +14804,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  return SZE_NOTIMPL;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,21 @@
 +/* 7zDecode.h */
 +
@@ -14829,8 +14829,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,116 @@
 +/* 7zExtract.c */
 +
@@ -14949,8 +14949,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,40 @@
 +/* 7zExtract.h */
 +
@@ -14993,8 +14993,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,5 @@
 +/*  7zHeader.c */
 +
@@ -15002,8 +15002,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,55 @@
 +/* 7zHeader.h */
 +
@@ -15061,8 +15061,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,1292 @@
 +/* 7zIn.c */
 +
@@ -16357,8 +16357,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,55 @@
 +/* 7zIn.h */
 +
@@ -16416,8 +16416,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 + 
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,133 @@
 +/* 7zItem.c */
 +
@@ -16553,8 +16553,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  SzArchiveDatabaseInit(db);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,90 @@
 +/* 7zItem.h */
 +
@@ -16647,8 +16647,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,223 @@
 +/* 
 +7zMain.c
@@ -16874,8 +16874,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  return 1;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,14 @@
 +/* 7zMethodID.c */
 +
@@ -16892,8 +16892,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +  return 1;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,18 @@
 +/* 7zMethodID.h */
 +
@@ -16914,8 +16914,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,61 @@
 +/* 7zTypes.h */
 +
@@ -16979,8 +16979,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,55 @@
 +PROG = 7zDec.exe
 +
@@ -17038,8 +17038,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,50 @@
 +PROG = 7zDec
 +CXX = g++
@@ -17092,8 +17092,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +	-$(RM) $(PROG) $(OBJS)
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,251 @@
 +// FileStreams.cpp
 +
@@ -17347,8 +17347,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +  
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,98 @@
 +// FileStreams.h
 +
@@ -17449,8 +17449,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,80 @@
 +// InBuffer.cpp
 +
@@ -17533,8 +17533,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +  return *_buffer++;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,76 @@
 +// InBuffer.h
 +
@@ -17613,8 +17613,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,117 @@
 +// OutByte.cpp
 +
@@ -17734,8 +17734,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +  #endif
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,64 @@
 +// OutBuffer.h
 +
@@ -17802,8 +17802,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -17815,8 +17815,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,44 @@
 +// StreamUtils.cpp
 +
@@ -17863,8 +17863,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +  return S_OK;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,11 @@
 +// StreamUtils.h
 +
@@ -17878,8 +17878,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,16 @@
 +// ARM.cpp
 +
@@ -17898,8 +17898,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return ::ARM_Convert(data, size, _bufferPos, 0);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// ARM.h
 +
@@ -17912,8 +17912,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,16 @@
 +// ARMThumb.cpp
 +
@@ -17932,8 +17932,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return ::ARMThumb_Convert(data, size, _bufferPos, 0);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// ARMThumb.h
 +
@@ -17946,8 +17946,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,26 @@
 +// BranchARM.c
 +
@@ -17976,8 +17976,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return i;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// BranchARM.h
 +
@@ -17990,8 +17990,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,35 @@
 +// BranchARMThumb.c
 +
@@ -18029,8 +18029,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return i;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// BranchARMThumb.h
 +
@@ -18043,8 +18043,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,18 @@
 +// BranchCoder.cpp
 +
@@ -18065,8 +18065,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return processedSize;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,54 @@
 +// BranchCoder.h
 +
@@ -18123,8 +18123,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,65 @@
 +// BranchIA64.c
 +
@@ -18192,8 +18192,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return i;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// BranchIA64.h
 +
@@ -18206,8 +18206,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,36 @@
 +// BranchPPC.c
 +
@@ -18246,8 +18246,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return i;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// BranchPPC.h
 +
@@ -18260,8 +18260,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,36 @@
 +// BranchSPARC.c
 +
@@ -18300,8 +18300,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return i;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// BranchSPARC.h
 +
@@ -18314,8 +18314,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,101 @@
 +/* BranchX86.c */
 +
@@ -18419,8 +18419,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return bufferPos;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,19 @@
 +/* BranchX86.h */
 +
@@ -18442,8 +18442,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,16 @@
 +// IA64.cpp
 +
@@ -18462,8 +18462,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return ::IA64_Convert(data, size, _bufferPos, 0);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// IA64.h
 +
@@ -18476,8 +18476,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,17 @@
 +// PPC.cpp
 +
@@ -18497,8 +18497,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return ::PPC_B_Convert(data, size, _bufferPos, 0);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// PPC.h
 +
@@ -18511,8 +18511,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,17 @@
 +// SPARC.cpp
 +
@@ -18532,8 +18532,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return ::SPARC_Convert(data, size, _bufferPos, 0);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +// SPARC.h
 +
@@ -18546,8 +18546,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -18558,8 +18558,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,412 @@
 +// x86_2.cpp
 +
@@ -18974,8 +18974,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  catch(...) { return S_FALSE; }
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,133 @@
 +// x86_2.h
 +
@@ -19111,8 +19111,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,18 @@
 +// x86.cpp
 +
@@ -19133,8 +19133,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return ::x86_Convert(data, size, _bufferPos, &_prevMask, &_prevPos, 0);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,19 @@
 +// x86.h
 +
@@ -19156,8 +19156,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,12 @@
 +// BinTree2.h
 +
@@ -19172,8 +19172,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,16 @@
 +// BinTree3.h
 +
@@ -19192,8 +19192,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,16 @@
 +// BinTree3Z.h
 +
@@ -19212,8 +19212,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,20 @@
 +// BinTree4b.h
 +
@@ -19236,8 +19236,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,18 @@
 +// BinTree4.h
 +
@@ -19258,8 +19258,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,55 @@
 +// BinTree.h
 +
@@ -19317,8 +19317,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,444 @@
 +// BinTreeMain.h
 +
@@ -19765,8 +19765,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 + 
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,13 @@
 +// HC2.h
 +
@@ -19782,8 +19782,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,17 @@
 +// HC3.h
 +
@@ -19803,8 +19803,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,21 @@
 +// HC4b.h
 +
@@ -19828,8 +19828,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,19 @@
 +// HC4.h
 +
@@ -19851,8 +19851,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,55 @@
 +// HC.h
 +
@@ -19910,8 +19910,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,350 @@
 +// HC.h
 +
@@ -20264,8 +20264,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 + 
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,63 @@
 +// MatchFinders/IMatchFinder.h
 +
@@ -20331,8 +20331,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,102 @@
 +// LZInWindow.cpp
 +
@@ -20437,8 +20437,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  AfterMoveBlock();
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,84 @@
 +// LZInWindow.h
 +
@@ -20525,8 +20525,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,17 @@
 +// LZOutWindow.cpp
 +
@@ -20546,8 +20546,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,64 @@
 +// LZOutWindow.h
 +
@@ -20614,8 +20614,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,22 @@
 +// Pat2.h
 +
@@ -20640,8 +20640,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,24 @@
 +// Pat2H.h
 +
@@ -20668,8 +20668,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,20 @@
 +// Pat2R.h
 +
@@ -20692,8 +20692,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,24 @@
 +// Pat3H.h
 +
@@ -20720,8 +20720,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,24 @@
 +// Pat4H.h
 +
@@ -20748,8 +20748,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,318 @@
 +// Pat.h
 +
@@ -21070,8 +21070,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +// #endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,989 @@
 +// PatMain.h
 +
@@ -22063,8 +22063,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -22073,8 +22073,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,342 @@
 +// LZMADecoder.cpp
 +
@@ -22419,8 +22419,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,249 @@
 +// LZMA/Decoder.h
 +
@@ -22672,8 +22672,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,1504 @@
 +// LZMA/Encoder.cpp
 +
@@ -24180,8 +24180,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,416 @@
 +// LZMA/Encoder.h
 +
@@ -24600,8 +24600,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,82 @@
 +// LZMA.h
 +
@@ -24686,8 +24686,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -24698,8 +24698,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,523 @@
 +# Microsoft Developer Studio Project File - Name="AloneLZMA" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -25225,8 +25225,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +# End Target
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -25258,8 +25258,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +###############################################################################
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,509 @@
 +// LzmaAlone.cpp
 +
@@ -25771,8 +25771,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  }
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,508 @@
 +// LzmaBench.cpp
 +
@@ -26283,8 +26283,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return 0;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,11 @@
 +// LzmaBench.h
 +
@@ -26298,8 +26298,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,228 @@
 +// LzmaRam.cpp
 +
@@ -26530,8 +26530,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  #endif
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,79 @@
 +/* LzmaRamDecode.c */
 +
@@ -26613,8 +26613,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return 0;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,55 @@
 +/* LzmaRamDecode.h */
 +
@@ -26672,8 +26672,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,46 @@
 +// LzmaRam.h
 +
@@ -26722,8 +26722,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,100 @@
 +PROG = lzma.exe
 +CFLAGS = $(CFLAGS) -I ../../../
@@ -26826,8 +26826,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +$O\FileIO.obj: ../../../Windows/FileIO.cpp
 +	$(COMPL)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,113 @@
 +PROG = lzma
 +CXX = g++ -O2 -Wall
@@ -26943,15 +26943,15 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	-$(RM) $(PROG) $(OBJS)
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,3 @@
 +// StdAfx.cpp
 +
 +#include "StdAfx.h"
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -26962,8 +26962,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,588 @@
 +/*
 +  LzmaDecode.c
@@ -27554,8 +27554,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return LZMA_RESULT_OK;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,131 @@
 +/* 
 +  LzmaDecode.h
@@ -27689,8 +27689,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,716 @@
 +/*
 +  LzmaDecodeSize.c
@@ -28409,8 +28409,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return LZMA_RESULT_OK;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,521 @@
 +/*
 +  LzmaStateDecode.c
@@ -28934,8 +28934,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return LZMA_RESULT_OK;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,115 @@
 +/* 
 +  LzmaStateDecode.h
@@ -29053,8 +29053,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,195 @@
 +/* 
 +LzmaStateTest.c
@@ -29252,8 +29252,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,342 @@
 +/* 
 +LzmaTest.c
@@ -29598,8 +29598,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +  return res;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,43 @@
 +PROG = lzmaDec.exe
 +
@@ -29645,8 +29645,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +$O\LzmaDecode.obj: ../../Compress/LZMA_C/$(*B).c
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,23 @@
 +PROG = lzmadec
 +CXX = gcc 
@@ -29672,8 +29672,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	-$(RM) $(PROG) $(OBJS)
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,21 @@
 +#ifndef __LZMA_LIB_H__
 +#define __LZMA_LIB_H__
@@ -29697,8 +29697,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,92 @@
 +PROG = liblzmalib.a
 +CXX = g++ -O3 -Wall
@@ -29793,8 +29793,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	-$(RM) $(PROG) $(OBJS)
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,451 @@
 +/*
 + * lzma zlib simplified wrapper
@@ -30248,8 +30248,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,80 @@
 +// Compress/RangeCoder/RangeCoderBit.cpp
 +
@@ -30332,8 +30332,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,120 @@
 +// Compress/RangeCoder/RangeCoderBit.h
 +
@@ -30456,8 +30456,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,161 @@
 +// Compress/RangeCoder/RangeCoderBitTree.h
 +
@@ -30621,8 +30621,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,205 @@
 +// Compress/RangeCoder/RangeCoder.h
 +
@@ -30830,8 +30830,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,31 @@
 +// Compress/RangeCoder/RangeCoderOpt.h
 +
@@ -30865,8 +30865,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -30875,8 +30875,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,156 @@
 +// ICoder.h
 +
@@ -31035,8 +31035,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h
---- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2016-08-25 09:06:03.227530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,62 @@
 +// IStream.h
 +
@@ -31101,8 +31101,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,118 @@
 +// Common/Alloc.cpp
 +
@@ -31223,8 +31223,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,29 @@
 +// Common/Alloc.h
 +
@@ -31256,8 +31256,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,78 @@
 +// Common/C_FileIO.h
 +
@@ -31338,8 +31338,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +
 +}}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,45 @@
 +// Common/C_FileIO.h
 +
@@ -31387,8 +31387,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,263 @@
 +// CommandLineParser.cpp
 +
@@ -31654,8 +31654,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,82 @@
 +// Common/CommandLineParser.h
 +
@@ -31740,8 +31740,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,17 @@
 +// ComTry.h
 +
@@ -31761,8 +31761,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,61 @@
 +// Common/CRC.cpp
 +
@@ -31826,8 +31826,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cp
 +  _value = v;
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,36 @@
 +// Common/CRC.h
 +
@@ -31866,8 +31866,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h 
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,20 @@
 +// Common/Defs.h
 +
@@ -31890,8 +31890,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,203 @@
 +// MyCom.h
 +
@@ -32097,8 +32097,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,54 @@
 +// Common/MyGuidDef.h
 +
@@ -32155,8 +32155,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuid
 +    MY_EXTERN_C const GUID name
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,13 @@
 +// Common/MyInitGuid.h
 +
@@ -32172,8 +32172,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInit
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,24 @@
 +// MyUnknown.h
 +
@@ -32200,8 +32200,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnkn
 +  
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,183 @@
 +// MyWindows.h
 +
@@ -32387,8 +32387,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWind
 +#endif
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,114 @@
 +// NewHandler.cpp
 + 
@@ -32505,8 +32505,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +}
 +*/
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,14 @@
 +// Common/NewHandler.h
 +
@@ -32523,8 +32523,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -32536,8 +32536,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx
 +
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,93 @@
 +// Common/StringConvert.cpp
 +
@@ -32633,8 +32633,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,71 @@
 +// Common/StringConvert.h
 +
@@ -32708,8 +32708,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,198 @@
 +// Common/String.cpp
 +
@@ -32910,8 +32910,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +}
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,631 @@
 +// Common/String.h
 +
@@ -33545,8 +33545,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,68 @@
 +// Common/StringToInt.cpp
 +
@@ -33617,8 +33617,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +  return ConvertStringToUInt64(s, end);
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,17 @@
 +// Common/StringToInt.h
 +
@@ -33638,8 +33638,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,19 @@
 +// Common/Types.h
 +
@@ -33661,8 +33661,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,74 @@
 +// Common/Vector.cpp
 +
@@ -33739,8 +33739,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +  }
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h
---- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,211 @@
 +// Common/Vector.h
 +
@@ -33954,8 +33954,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,18 @@
 +// Windows/Defs.h
 +
@@ -33976,8 +33976,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,245 @@
 +// Windows/FileIO.cpp
 +
@@ -34225,8 +34225,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +
 +}}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,98 @@
 +// Windows/FileIO.h
 +
@@ -34327,8 +34327,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h
---- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -34340,8 +34340,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAf
 +
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squashfs-tools-patched/LZMA/lzmadaptive/CPL.html
---- squashfs-tools/LZMA/lzmadaptive/CPL.html	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/CPL.html	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,224 @@
 +<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 +<HTML><HEAD><TITLE>Common Public License - v 1.0</TITLE>
@@ -34568,8 +34568,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squash
 +<P><FONT size=2></FONT><FONT size=2></FONT>
 +<P><FONT size=2></FONT></P></BODY></HTML>
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squashfs-tools-patched/LZMA/lzmadaptive/history.txt
---- squashfs-tools/LZMA/lzmadaptive/history.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/history.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,147 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -34719,8 +34719,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squ
 +
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt
---- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,504 @@
 +      GNU LESSER GENERAL PUBLIC LICENSE
 +           Version 2.1, February 1999
@@ -35227,8 +35227,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squash
 +
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt
---- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,637 @@
 +LZMA SDK 4.32
 +-------------
@@ -35868,8 +35868,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squash
 +http://www.7-zip.org
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt
---- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,114 @@
 +Compression method IDs (4.27)
 +-----------------------------
@@ -35986,8 +35986,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squ
 +---
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-tools-patched/LZMA/lzmalt/7zlzma.c
---- squashfs-tools/LZMA/lzmalt/7zlzma.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/7zlzma.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,58 @@
 +#include "lzmalt.h"
 +
@@ -36048,8 +36048,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-to
 +
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h
---- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,51 @@
 +#ifndef __COMPRESSION_BITCODER_H
 +#define __COMPRESSION_BITCODER_H
@@ -36103,8 +36103,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squash
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h
---- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,160 @@
 +#ifndef __BITTREECODER_H
 +#define __BITTREECODER_H
@@ -36267,8 +36267,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squas
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,39 @@
 +#include "stdlib.h"
 +#include "IInOutStreams.h"
@@ -36310,8 +36310,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squa
 +    }
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h
---- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,62 @@
 +#ifndef __IINOUTSTREAMS_H
 +#define __IINOUTSTREAMS_H
@@ -36376,8 +36376,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squa
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-tools-patched/LZMA/lzmalt/LenCoder.h
---- squashfs-tools/LZMA/lzmalt/LenCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/LenCoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,75 @@
 +#ifndef __LENCODER_H
 +#define __LENCODER_H
@@ -36455,8 +36455,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h
---- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,146 @@
 +#ifndef __LITERALCODER_H
 +#define __LITERALCODER_H
@@ -36605,8 +36605,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squas
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,417 @@
 +#include "Portable.h"
 +#include "stdio.h"
@@ -37026,8 +37026,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squash
 +}
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h
---- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,60 @@
 +#ifndef __LZARITHMETIC_DECODER_H
 +#define __LZARITHMETIC_DECODER_H
@@ -37090,8 +37090,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squash
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tools-patched/LZMA/lzmalt/LZMA.h
---- squashfs-tools/LZMA/lzmalt/LZMA.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/LZMA.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,83 @@
 +#include "LenCoder.h"
 +
@@ -37177,8 +37177,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tool
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-tools-patched/LZMA/lzmalt/lzmalt.h
---- squashfs-tools/LZMA/lzmalt/lzmalt.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/lzmalt.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,16 @@
 +#ifndef __7Z_H
 +#define __7Z_H
@@ -37197,8 +37197,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-to
 +#endif
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-tools-patched/LZMA/lzmalt/Makefile
---- squashfs-tools/LZMA/lzmalt/Makefile	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/Makefile	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,10 @@
 +INCLUDEDIR = .
 +
@@ -37211,8 +37211,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-to
 +clean :
 +	rm -f *.o
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-tools-patched/LZMA/lzmalt/Portable.h
---- squashfs-tools/LZMA/lzmalt/Portable.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/Portable.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,59 @@
 +#ifndef __PORTABLE_H
 +#define __PORTABLE_H
@@ -37274,8 +37274,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h
---- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,56 @@
 +#ifndef __COMPRESSION_RANGECODER_H
 +#define __COMPRESSION_RANGECODER_H
@@ -37334,8 +37334,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashf
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-tools-patched/LZMA/lzmalt/RCDefs.h
---- squashfs-tools/LZMA/lzmalt/RCDefs.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/RCDefs.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,43 @@
 +#ifndef __RCDEFS_H
 +#define __RCDEFS_H
@@ -37381,8 +37381,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-to
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h
---- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,289 @@
 +/* vxTypesOld.h - old VxWorks type definition header */
 +
@@ -37674,8 +37674,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashf
 +
 +#endif /* __INCvxTypesOldh */
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs-tools-patched/LZMA/lzmalt/WindowOut.h
---- squashfs-tools/LZMA/lzmalt/WindowOut.h	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/LZMA/lzmalt/WindowOut.h	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,52 @@
 +#ifndef __STREAM_WINDOWOUT_H
 +#define __STREAM_WINDOWOUT_H
@@ -37730,8 +37730,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs
 +
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-patched/lzma_wrapper.c
---- squashfs-tools/lzma_wrapper.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/lzma_wrapper.c	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/lzma_wrapper.c	2014-03-09 06:31:58.000000000 +0100
++++ squashfs-tools-patched/lzma_wrapper.c	2023-05-23 16:19:06.325285093 +0200
 @@ -27,14 +27,21 @@
  #include "squashfs_fs.h"
  #include "compressor.h"
@@ -38077,8 +38077,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
 +};
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/Makefile
---- squashfs-tools/Makefile	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/Makefile	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/Makefile	2014-05-11 20:56:00.000000000 +0200
++++ squashfs-tools-patched/Makefile	2023-05-23 16:19:06.325285093 +0200
 @@ -26,7 +26,7 @@
  # To build using XZ Utils liblzma - install the library and uncomment
  # the XZ_SUPPORT line below.
@@ -38215,8 +38215,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
 -	cp unsquashfs $(INSTALL_DIR)
 +	cp sasquatch $(INSTALL_DIR)
 diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-tools-patched/process_fragments.c
---- squashfs-tools/process_fragments.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/process_fragments.c	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/process_fragments.c	2014-05-10 06:54:13.000000000 +0200
++++ squashfs-tools-patched/process_fragments.c	2023-05-23 16:19:06.325285093 +0200
 @@ -192,9 +192,10 @@
  
  		res = compressor_uncompress(comp, buffer->data, data, size,
@@ -38232,8 +38232,8 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-too
  		memcpy(buffer->data, compressed_buffer->data, size);
  	else {
 diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched/read_fs.c
---- squashfs-tools/read_fs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/read_fs.c	2016-08-25 09:06:03.231530353 -0400
+--- squashfs-tools/read_fs.c	2014-05-10 06:54:13.000000000 +0200
++++ squashfs-tools-patched/read_fs.c	2023-05-23 16:19:06.325285093 +0200
 @@ -87,8 +87,9 @@
  		res = compressor_uncompress(comp, block, buffer, c_byte,
  			outlen, &error);
@@ -38247,14 +38247,14 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched
  		}
  	} else {
 diff --strip-trailing-cr -NBbaur squashfs-tools/README.md squashfs-tools-patched/README.md
---- squashfs-tools/README.md	1969-12-31 19:00:00.000000000 -0500
-+++ squashfs-tools-patched/README.md	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/README.md	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/README.md	2023-05-23 16:19:06.325285093 +0200
 @@ -0,0 +1,2 @@
 +This is the raw, patched source code for squashfs-tools. It is included in this repository for documentation and administrative purposes only. Any bugs or patches not directly related to the modifications made by the sasquatch patches should be reported to the squashfs-tools project.
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-patched/squashfs_fs.h
---- squashfs-tools/squashfs_fs.h	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/squashfs_fs.h	2016-08-25 09:06:03.223530354 -0400
+--- squashfs-tools/squashfs_fs.h	2014-05-10 06:54:13.000000000 +0200
++++ squashfs-tools-patched/squashfs_fs.h	2023-05-23 16:19:06.325285093 +0200
 @@ -277,6 +277,22 @@
  #define LZO_COMPRESSION		3
  #define XZ_COMPRESSION		4
@@ -38301,18 +38301,22 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-pat
 +
  #endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
---- squashfs-tools/unsquashfs.c	2016-08-25 09:06:22.983529595 -0400
-+++ squashfs-tools-patched/unsquashfs.c	2016-08-25 09:06:03.223530354 -0400
-@@ -32,7 +32,8 @@
- #include "stdarg.h"
-
+--- squashfs-tools/unsquashfs.c	2014-05-13 00:18:35.000000000 +0200
++++ squashfs-tools-patched/unsquashfs.c	2023-05-23 16:19:06.325285093 +0200
+@@ -33,24 +33,32 @@
+ 
  #include <sys/sysinfo.h>
  #include <sys/types.h>
 +#include <sys/sysmacros.h>
  #include <sys/time.h>
  #include <sys/resource.h>
  #include <limits.h>
-@@ -44,13 +44,19 @@
+ #include <ctype.h>
+ 
++int verbose;
+ struct cache *fragment_cache, *data_cache;
+ struct queue *to_reader, *to_inflate, *to_writer, *from_writer;
+ pthread_t *thread, *inflator_thread;
  pthread_mutex_t	fragment_mutex;
  
  /* user options that control parallelisation */
@@ -38336,7 +38340,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	dev_count = 0, fifo_count = 0;
  char *inode_table = NULL, *directory_table = NULL;
  struct hash_table_entry *inode_table_hash[65536], *directory_table_hash[65536];
-@@ -701,8 +707,9 @@
+@@ -701,8 +709,9 @@
  			outlen, &error);
  
  		if(res == -1) {
@@ -38348,7 +38352,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  			goto failed;
  		}
  	} else {
-@@ -720,7 +727,10 @@
+@@ -720,7 +729,10 @@
  	 * is of the expected size
  	 */
  	if(expected && expected != res)
@@ -38359,7 +38363,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	else
  		return res;
  
-@@ -747,8 +757,9 @@
+@@ -747,8 +759,9 @@
  			block_size, &error);
  
  		if(res == -1) {
@@ -38371,7 +38375,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  			goto failed;
  		}
  
-@@ -1622,7 +1633,7 @@
+@@ -1622,7 +1635,7 @@
  	dir_count ++;
  }
  
@@ -38380,7 +38384,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  void squashfs_stat(char *source)
  {
  	time_t mkfs_time = (time_t) sBlk.s.mkfs_time;
-@@ -1640,9 +1651,10 @@
+@@ -1640,9 +1653,10 @@
  
  	printf("Creation or last append time %s", mkfs_str ? mkfs_str :
  		"failed to get time\n");
@@ -38389,12 +38393,12 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 -		(1024.0 * 1024.0));
 +    // CJH: Added bytes output
 +	printf("Filesystem size %.2f Kbytes (%.2f Mbytes) (%lld [0x%llX] bytes)\n",
-+		(sBlk.s.bytes_used / 1024.0), (sBlk.s.bytes_used / (1024.0 * 1024.0)), 
++		(sBlk.s.bytes_used / 1024.0), (sBlk.s.bytes_used / (1024.0 * 1024.0)),
 +        sBlk.s.bytes_used, sBlk.s.bytes_used);
  
  	if(sBlk.s.s_major == 4) {
  		printf("Compression %s\n", comp->name);
-@@ -1714,25 +1726,25 @@
+@@ -1714,25 +1728,25 @@
  		printf("Number of gids %d\n", sBlk.no_guids);
  	}
  
@@ -38428,7 +38432,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	}
  }
  
-@@ -1745,9 +1757,11 @@
+@@ -1745,9 +1759,11 @@
  	if(!comp->supported) {
  		ERROR("Filesystem uses %s compression, this is "
  			"unsupported by this version\n", comp->name);
@@ -38443,7 +38447,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	}
  
  	/*
-@@ -1777,17 +1791,74 @@
+@@ -1777,17 +1793,75 @@
  {
  	squashfs_super_block_3 sBlk_3;
  	struct squashfs_super_block sBlk_4;
@@ -38460,7 +38464,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 +         * or if the least significant bytes of the inode count field is 0, then the
 +         * image endianess is probably opposite of the host system.
 +         *
-+         * Note that these are the only fields besides s_magic that are common among 
++         * Note that these are the only fields besides s_magic that are common among
 +         * all versions of the SquashFS super block structures, and s_magic cannot
 +         * be relied on as it is commonly mucked with by vendors.
 +         */
@@ -38479,7 +38483,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 +            swap = 0;
 +        }
 +    }
-+    
++
 +    // CJH: Warn if SquashFS magic doesn't look correct
 +    if(generic.s_magic != SQUASHFS_MAGIC && generic.s_magic != SQUASHFS_MAGIC_SWAP)
 +    {
@@ -38487,8 +38491,9 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
 +    }
 +
 +    // CJH: Notify if endianess is different
-+    if(swap)
++    if(swap) {
 +        ERROR("Reading a different endian SQUASHFS filesystem on %s\n", source);
++    }
  
  	/*
  	 * Try to read a Squashfs 4 superblock
@@ -38519,7 +38524,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		s_ops.squashfs_opendir = squashfs_opendir_4;
  		s_ops.read_fragment = read_fragment_4;
  		s_ops.read_fragment_table = read_fragment_table_4;
-@@ -1799,7 +1870,11 @@
+@@ -1799,7 +1873,11 @@
  		/*
  		 * Check the compression type
  		 */
@@ -38531,7 +38536,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		return TRUE;
  	}
  
-@@ -1813,6 +1888,9 @@
+@@ -1813,6 +1891,9 @@
  	/*
  	 * Check it is a SQUASHFS superblock
  	 */
@@ -38541,7 +38546,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	swap = 0;
  	if(sBlk_3.s_magic != SQUASHFS_MAGIC) {
  		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP) {
-@@ -1828,6 +1906,13 @@
+@@ -1828,6 +1909,13 @@
  			goto failed_mount;
  		}
  	}
@@ -38555,7 +38560,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  
  	sBlk.s.s_magic = sBlk_3.s_magic;
  	sBlk.s.inodes = sBlk_3.inodes;
-@@ -1850,14 +1935,22 @@
+@@ -1850,14 +1938,22 @@
  	sBlk.guid_start = sBlk_3.guid_start;
  	sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
  
@@ -38579,7 +38584,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		if(sBlk.s.s_major == 1) {
  			sBlk.s.block_size = sBlk_3.block_size_1;
  			sBlk.s.fragment_table_start = sBlk.uid_start;
-@@ -1893,7 +1986,11 @@
+@@ -1893,7 +1989,11 @@
  	/*
  	 * 1.x, 2.x and 3.x filesystems use gzip compression.
  	 */
@@ -38591,7 +38596,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	return TRUE;
  
  failed_mount:
-@@ -2106,11 +2203,15 @@
+@@ -2106,11 +2206,15 @@
  			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size), block_size,
  			&error);
  
@@ -38607,7 +38612,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  
  		/*
  		 * block has been either successfully decompressed, or an error
-@@ -2505,6 +2606,9 @@
+@@ -2505,6 +2609,9 @@
  	int fragment_buffer_size = FRAGMENT_BUFFER_DEFAULT;
  	int data_buffer_size = DATA_BUFFER_DEFAULT;
  
@@ -38617,7 +38622,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  	pthread_mutex_init(&screen_mutex, NULL);
  	root_process = geteuid() == 0;
  	if(root_process)
-@@ -2611,6 +2715,83 @@
+@@ -2611,6 +2718,83 @@
  		} else if(strcmp(argv[i], "-regex") == 0 ||
  				strcmp(argv[i], "-r") == 0)
  			use_regex = TRUE;
@@ -38701,7 +38706,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		else
  			goto options;
  	}
-@@ -2674,6 +2855,22 @@
+@@ -2674,6 +2858,22 @@
  				"regular expressions\n");
  			ERROR("\t\t\t\trather than use the default shell "
  				"wildcard\n\t\t\t\texpansion (globbing)\n");
@@ -38724,3 +38729,2821 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  			ERROR("\nDecompressors available:\n");
  			display_compressors("", "");
  		}
+diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c.orig squashfs-tools-patched/unsquashfs.c.orig
+--- squashfs-tools/unsquashfs.c.orig	1970-01-01 01:00:00.000000000 +0100
++++ squashfs-tools-patched/unsquashfs.c.orig	2023-05-23 16:19:06.321285058 +0200
+@@ -0,0 +1,2814 @@
++/*
++ * Unsquash a squashfs filesystem.  This is a highly compressed read only
++ * filesystem.
++ *
++ * Copyright (c) 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
++ * 2012, 2013, 2014
++ * Phillip Lougher <phillip@squashfs.org.uk>
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * as published by the Free Software Foundation; either version 2,
++ * or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *
++ * unsquashfs.c
++ */
++
++#include "unsquashfs.h"
++#include "squashfs_swap.h"
++#include "squashfs_compat.h"
++#include "compressor.h"
++#include "xattr.h"
++#include "unsquashfs_info.h"
++#include "stdarg.h"
++
++#include <sys/sysinfo.h>
++#include <sys/types.h>
++#include <sys/time.h>
++#include <sys/resource.h>
++#include <limits.h>
++#include <ctype.h>
++
++struct cache *fragment_cache, *data_cache;
++struct queue *to_reader, *to_inflate, *to_writer, *from_writer;
++pthread_t *thread, *inflator_thread;
++pthread_mutex_t	fragment_mutex;
++
++/* user options that control parallelisation */
++int processors = -1;
++
++struct super_block sBlk;
++squashfs_operations s_ops;
++struct compressor *comp;
++
++int bytes = 0, swap, file_count = 0, dir_count = 0, sym_count = 0,
++	dev_count = 0, fifo_count = 0;
++char *inode_table = NULL, *directory_table = NULL;
++struct hash_table_entry *inode_table_hash[65536], *directory_table_hash[65536];
++int fd;
++unsigned int *uid_table, *guid_table;
++unsigned int cached_frag = SQUASHFS_INVALID_FRAG;
++char *fragment_data;
++char *file_data;
++char *data;
++unsigned int block_size;
++unsigned int block_log;
++int lsonly = FALSE, info = FALSE, force = FALSE, short_ls = TRUE;
++int use_regex = FALSE;
++char **created_inode;
++int root_process;
++int columns;
++int rotate = 0;
++pthread_mutex_t	screen_mutex;
++int progress = TRUE, progress_enabled = FALSE;
++unsigned int total_blocks = 0, total_files = 0, total_inodes = 0;
++unsigned int cur_blocks = 0;
++int inode_number = 1;
++int no_xattrs = XATTR_DEF;
++int user_xattrs = FALSE;
++
++int lookup_type[] = {
++	0,
++	S_IFDIR,
++	S_IFREG,
++	S_IFLNK,
++	S_IFBLK,
++	S_IFCHR,
++	S_IFIFO,
++	S_IFSOCK,
++	S_IFDIR,
++	S_IFREG,
++	S_IFLNK,
++	S_IFBLK,
++	S_IFCHR,
++	S_IFIFO,
++	S_IFSOCK
++};
++
++struct test table[] = {
++	{ S_IFMT, S_IFSOCK, 0, 's' },
++	{ S_IFMT, S_IFLNK, 0, 'l' },
++	{ S_IFMT, S_IFBLK, 0, 'b' },
++	{ S_IFMT, S_IFDIR, 0, 'd' },
++	{ S_IFMT, S_IFCHR, 0, 'c' },
++	{ S_IFMT, S_IFIFO, 0, 'p' },
++	{ S_IRUSR, S_IRUSR, 1, 'r' },
++	{ S_IWUSR, S_IWUSR, 2, 'w' },
++	{ S_IRGRP, S_IRGRP, 4, 'r' },
++	{ S_IWGRP, S_IWGRP, 5, 'w' },
++	{ S_IROTH, S_IROTH, 7, 'r' },
++	{ S_IWOTH, S_IWOTH, 8, 'w' },
++	{ S_IXUSR | S_ISUID, S_IXUSR | S_ISUID, 3, 's' },
++	{ S_IXUSR | S_ISUID, S_ISUID, 3, 'S' },
++	{ S_IXUSR | S_ISUID, S_IXUSR, 3, 'x' },
++	{ S_IXGRP | S_ISGID, S_IXGRP | S_ISGID, 6, 's' },
++	{ S_IXGRP | S_ISGID, S_ISGID, 6, 'S' },
++	{ S_IXGRP | S_ISGID, S_IXGRP, 6, 'x' },
++	{ S_IXOTH | S_ISVTX, S_IXOTH | S_ISVTX, 9, 't' },
++	{ S_IXOTH | S_ISVTX, S_ISVTX, 9, 'T' },
++	{ S_IXOTH | S_ISVTX, S_IXOTH, 9, 'x' },
++	{ 0, 0, 0, 0}
++};
++
++void progress_bar(long long current, long long max, int columns);
++
++#define MAX_LINE 16384
++
++void prep_exit()
++{
++}
++
++
++void sigwinch_handler()
++{
++	struct winsize winsize;
++
++	if(ioctl(1, TIOCGWINSZ, &winsize) == -1) {
++		if(isatty(STDOUT_FILENO))
++			ERROR("TIOCGWINSZ ioctl failed, defaulting to 80 "
++				"columns\n");
++		columns = 80;
++	} else
++		columns = winsize.ws_col;
++}
++
++
++void sigalrm_handler()
++{
++	rotate = (rotate + 1) % 4;
++}
++
++
++int add_overflow(int a, int b)
++{
++	return (INT_MAX - a) < b;
++}
++
++
++int shift_overflow(int a, int shift)
++{
++	return (INT_MAX >> shift) < a;
++}
++
++ 
++int multiply_overflow(int a, int multiplier)
++{
++	return (INT_MAX / multiplier) < a;
++}
++
++
++struct queue *queue_init(int size)
++{
++	struct queue *queue = malloc(sizeof(struct queue));
++
++	if(queue == NULL)
++		EXIT_UNSQUASH("Out of memory in queue_init\n");
++
++	if(add_overflow(size, 1) ||
++				multiply_overflow(size + 1, sizeof(void *)))
++		EXIT_UNSQUASH("Size too large in queue_init\n");
++
++	queue->data = malloc(sizeof(void *) * (size + 1));
++	if(queue->data == NULL)
++		EXIT_UNSQUASH("Out of memory in queue_init\n");
++
++	queue->size = size + 1;
++	queue->readp = queue->writep = 0;
++	pthread_mutex_init(&queue->mutex, NULL);
++	pthread_cond_init(&queue->empty, NULL);
++	pthread_cond_init(&queue->full, NULL);
++
++	return queue;
++}
++
++
++void queue_put(struct queue *queue, void *data)
++{
++	int nextp;
++
++	pthread_mutex_lock(&queue->mutex);
++
++	while((nextp = (queue->writep + 1) % queue->size) == queue->readp)
++		pthread_cond_wait(&queue->full, &queue->mutex);
++
++	queue->data[queue->writep] = data;
++	queue->writep = nextp;
++	pthread_cond_signal(&queue->empty);
++	pthread_mutex_unlock(&queue->mutex);
++}
++
++
++void *queue_get(struct queue *queue)
++{
++	void *data;
++	pthread_mutex_lock(&queue->mutex);
++
++	while(queue->readp == queue->writep)
++		pthread_cond_wait(&queue->empty, &queue->mutex);
++
++	data = queue->data[queue->readp];
++	queue->readp = (queue->readp + 1) % queue->size;
++	pthread_cond_signal(&queue->full);
++	pthread_mutex_unlock(&queue->mutex);
++
++	return data;
++}
++
++
++void dump_queue(struct queue *queue)
++{
++	pthread_mutex_lock(&queue->mutex);
++
++	printf("Max size %d, size %d%s\n", queue->size - 1,  
++		queue->readp <= queue->writep ? queue->writep - queue->readp :
++			queue->size - queue->readp + queue->writep,
++		queue->readp == queue->writep ? " (EMPTY)" :
++			((queue->writep + 1) % queue->size) == queue->readp ?
++			" (FULL)" : "");
++
++	pthread_mutex_unlock(&queue->mutex);
++}
++
++
++/* Called with the cache mutex held */
++void insert_hash_table(struct cache *cache, struct cache_entry *entry)
++{
++	int hash = CALCULATE_HASH(entry->block);
++
++	entry->hash_next = cache->hash_table[hash];
++	cache->hash_table[hash] = entry;
++	entry->hash_prev = NULL;
++	if(entry->hash_next)
++		entry->hash_next->hash_prev = entry;
++}
++
++
++/* Called with the cache mutex held */
++void remove_hash_table(struct cache *cache, struct cache_entry *entry)
++{
++	if(entry->hash_prev)
++		entry->hash_prev->hash_next = entry->hash_next;
++	else
++		cache->hash_table[CALCULATE_HASH(entry->block)] =
++			entry->hash_next;
++	if(entry->hash_next)
++		entry->hash_next->hash_prev = entry->hash_prev;
++
++	entry->hash_prev = entry->hash_next = NULL;
++}
++
++
++/* Called with the cache mutex held */
++void insert_free_list(struct cache *cache, struct cache_entry *entry)
++{
++	if(cache->free_list) {
++		entry->free_next = cache->free_list;
++		entry->free_prev = cache->free_list->free_prev;
++		cache->free_list->free_prev->free_next = entry;
++		cache->free_list->free_prev = entry;
++	} else {
++		cache->free_list = entry;
++		entry->free_prev = entry->free_next = entry;
++	}
++}
++
++
++/* Called with the cache mutex held */
++void remove_free_list(struct cache *cache, struct cache_entry *entry)
++{
++	if(entry->free_prev == NULL || entry->free_next == NULL)
++		/* not in free list */
++		return;
++	else if(entry->free_prev == entry && entry->free_next == entry) {
++		/* only this entry in the free list */
++		cache->free_list = NULL;
++	} else {
++		/* more than one entry in the free list */
++		entry->free_next->free_prev = entry->free_prev;
++		entry->free_prev->free_next = entry->free_next;
++		if(cache->free_list == entry)
++			cache->free_list = entry->free_next;
++	}
++
++	entry->free_prev = entry->free_next = NULL;
++}
++
++
++struct cache *cache_init(int buffer_size, int max_buffers)
++{
++	struct cache *cache = malloc(sizeof(struct cache));
++
++	if(cache == NULL)
++		EXIT_UNSQUASH("Out of memory in cache_init\n");
++
++	cache->max_buffers = max_buffers;
++	cache->buffer_size = buffer_size;
++	cache->count = 0;
++	cache->used = 0;
++	cache->free_list = NULL;
++	memset(cache->hash_table, 0, sizeof(struct cache_entry *) * 65536);
++	cache->wait_free = FALSE;
++	cache->wait_pending = FALSE;
++	pthread_mutex_init(&cache->mutex, NULL);
++	pthread_cond_init(&cache->wait_for_free, NULL);
++	pthread_cond_init(&cache->wait_for_pending, NULL);
++
++	return cache;
++}
++
++
++struct cache_entry *cache_get(struct cache *cache, long long block, int size)
++{
++	/*
++	 * Get a block out of the cache.  If the block isn't in the cache
++ 	 * it is added and queued to the reader() and inflate() threads for
++ 	 * reading off disk and decompression.  The cache grows until max_blocks
++ 	 * is reached, once this occurs existing discarded blocks on the free
++ 	 * list are reused
++ 	 */
++	int hash = CALCULATE_HASH(block);
++	struct cache_entry *entry;
++
++	pthread_mutex_lock(&cache->mutex);
++
++	for(entry = cache->hash_table[hash]; entry; entry = entry->hash_next)
++		if(entry->block == block)
++			break;
++
++	if(entry) {
++		/*
++ 		 * found the block in the cache.  If the block is currently unused
++		 * remove it from the free list and increment cache used count.
++ 		 */
++		if(entry->used == 0) {
++			cache->used ++;
++			remove_free_list(cache, entry);
++		}
++		entry->used ++;
++		pthread_mutex_unlock(&cache->mutex);
++	} else {
++		/*
++ 		 * not in the cache
++		 *
++		 * first try to allocate new block
++		 */
++		if(cache->count < cache->max_buffers) {
++			entry = malloc(sizeof(struct cache_entry));
++			if(entry == NULL)
++				EXIT_UNSQUASH("Out of memory in cache_get\n");
++			entry->data = malloc(cache->buffer_size);
++			if(entry->data == NULL)
++				EXIT_UNSQUASH("Out of memory in cache_get\n");
++			entry->cache = cache;
++			entry->free_prev = entry->free_next = NULL;
++			cache->count ++;
++		} else {
++			/*
++			 * try to get from free list
++			 */
++			while(cache->free_list == NULL) {
++				cache->wait_free = TRUE;
++				pthread_cond_wait(&cache->wait_for_free,
++					&cache->mutex);
++			}
++			entry = cache->free_list;
++			remove_free_list(cache, entry);
++			remove_hash_table(cache, entry);
++		}
++
++		/*
++		 * Initialise block and insert into the hash table.
++		 * Increment used which tracks how many buffers in the
++		 * cache are actively in use (the other blocks, count - used,
++		 * are in the cache and available for lookup, but can also be
++		 * re-used).
++		 */
++		entry->block = block;
++		entry->size = size;
++		entry->used = 1;
++		entry->error = FALSE;
++		entry->pending = TRUE;
++		insert_hash_table(cache, entry);
++		cache->used ++;
++
++		/*
++		 * queue to read thread to read and ultimately (via the
++		 * decompress threads) decompress the buffer
++ 		 */
++		pthread_mutex_unlock(&cache->mutex);
++		queue_put(to_reader, entry);
++	}
++
++	return entry;
++}
++
++	
++void cache_block_ready(struct cache_entry *entry, int error)
++{
++	/*
++	 * mark cache entry as being complete, reading and (if necessary)
++ 	 * decompression has taken place, and the buffer is valid for use.
++ 	 * If an error occurs reading or decompressing, the buffer also 
++ 	 * becomes ready but with an error...
++ 	 */
++	pthread_mutex_lock(&entry->cache->mutex);
++	entry->pending = FALSE;
++	entry->error = error;
++
++	/*
++	 * if the wait_pending flag is set, one or more threads may be waiting
++	 * on this buffer
++	 */
++	if(entry->cache->wait_pending) {
++		entry->cache->wait_pending = FALSE;
++		pthread_cond_broadcast(&entry->cache->wait_for_pending);
++	}
++
++	pthread_mutex_unlock(&entry->cache->mutex);
++}
++
++
++void cache_block_wait(struct cache_entry *entry)
++{
++	/*
++	 * wait for this cache entry to become ready, when reading and (if
++	 * necessary) decompression has taken place
++	 */
++	pthread_mutex_lock(&entry->cache->mutex);
++
++	while(entry->pending) {
++		entry->cache->wait_pending = TRUE;
++		pthread_cond_wait(&entry->cache->wait_for_pending,
++			&entry->cache->mutex);
++	}
++
++	pthread_mutex_unlock(&entry->cache->mutex);
++}
++
++
++void cache_block_put(struct cache_entry *entry)
++{
++	/*
++	 * finished with this cache entry, once the usage count reaches zero it
++ 	 * can be reused and is put onto the free list.  As it remains
++ 	 * accessible via the hash table it can be found getting a new lease of
++ 	 * life before it is reused.
++ 	 */
++	pthread_mutex_lock(&entry->cache->mutex);
++
++	entry->used --;
++	if(entry->used == 0) {
++		insert_free_list(entry->cache, entry);
++		entry->cache->used --;
++
++		/*
++		 * if the wait_free flag is set, one or more threads may be
++		 * waiting on this buffer
++		 */
++		if(entry->cache->wait_free) {
++			entry->cache->wait_free = FALSE;
++			pthread_cond_broadcast(&entry->cache->wait_for_free);
++		}
++	}
++
++	pthread_mutex_unlock(&entry->cache->mutex);
++}
++
++
++void dump_cache(struct cache *cache)
++{
++	pthread_mutex_lock(&cache->mutex);
++
++	printf("Max buffers %d, Current size %d, Used %d,  %s\n",
++		cache->max_buffers, cache->count, cache->used,
++		cache->free_list ?  "Free buffers" : "No free buffers");
++
++	pthread_mutex_unlock(&cache->mutex);
++}
++
++
++char *modestr(char *str, int mode)
++{
++	int i;
++
++	strcpy(str, "----------");
++
++	for(i = 0; table[i].mask != 0; i++) {
++		if((mode & table[i].mask) == table[i].value)
++			str[table[i].position] = table[i].mode;
++	}
++
++	return str;
++}
++
++
++#define TOTALCHARS  25
++int print_filename(char *pathname, struct inode *inode)
++{
++	char str[11], dummy[12], dummy2[12]; /* overflow safe */
++	char *userstr, *groupstr;
++	int padchars;
++	struct passwd *user;
++	struct group *group;
++	struct tm *t;
++
++	if(short_ls) {
++		printf("%s\n", pathname);
++		return 1;
++	}
++
++	user = getpwuid(inode->uid);
++	if(user == NULL) {
++		int res = snprintf(dummy, 12, "%d", inode->uid);
++		if(res < 0)
++			EXIT_UNSQUASH("snprintf failed in print_filename()\n");
++		else if(res >= 12)
++			/* unsigned int shouldn't ever need more than 11 bytes
++			 * (including terminating '\0') to print in base 10 */
++			userstr = "*";
++		else
++			userstr = dummy;
++	} else
++		userstr = user->pw_name;
++		 
++	group = getgrgid(inode->gid);
++	if(group == NULL) {
++		int res = snprintf(dummy2, 12, "%d", inode->gid);
++		if(res < 0)
++			EXIT_UNSQUASH("snprintf failed in print_filename()\n");
++		else if(res >= 12)
++			/* unsigned int shouldn't ever need more than 11 bytes
++			 * (including terminating '\0') to print in base 10 */
++			groupstr = "*";
++		else
++			groupstr = dummy2;
++	} else
++		groupstr = group->gr_name;
++
++	printf("%s %s/%s ", modestr(str, inode->mode), userstr, groupstr);
++
++	switch(inode->mode & S_IFMT) {
++		case S_IFREG:
++		case S_IFDIR:
++		case S_IFSOCK:
++		case S_IFIFO:
++		case S_IFLNK:
++			padchars = TOTALCHARS - strlen(userstr) -
++				strlen(groupstr);
++
++			printf("%*lld ", padchars > 0 ? padchars : 0,
++				inode->data);
++			break;
++		case S_IFCHR:
++		case S_IFBLK:
++			padchars = TOTALCHARS - strlen(userstr) -
++				strlen(groupstr) - 7; 
++
++			printf("%*s%3d,%3d ", padchars > 0 ? padchars : 0, " ",
++				(int) inode->data >> 8, (int) inode->data &
++				0xff);
++			break;
++	}
++
++	t = localtime(&inode->time);
++
++	printf("%d-%02d-%02d %02d:%02d %s", t->tm_year + 1900, t->tm_mon + 1,
++		t->tm_mday, t->tm_hour, t->tm_min, pathname);
++	if((inode->mode & S_IFMT) == S_IFLNK)
++		printf(" -> %s", inode->symlink);
++	printf("\n");
++		
++	return 1;
++}
++	
++
++void add_entry(struct hash_table_entry *hash_table[], long long start,
++	int bytes)
++{
++	int hash = CALCULATE_HASH(start);
++	struct hash_table_entry *hash_table_entry;
++
++	hash_table_entry = malloc(sizeof(struct hash_table_entry));
++	if(hash_table_entry == NULL)
++		EXIT_UNSQUASH("Out of memory in add_entry\n");
++
++	hash_table_entry->start = start;
++	hash_table_entry->bytes = bytes;
++	hash_table_entry->next = hash_table[hash];
++	hash_table[hash] = hash_table_entry;
++}
++
++
++int lookup_entry(struct hash_table_entry *hash_table[], long long start)
++{
++	int hash = CALCULATE_HASH(start);
++	struct hash_table_entry *hash_table_entry;
++
++	for(hash_table_entry = hash_table[hash]; hash_table_entry;
++				hash_table_entry = hash_table_entry->next)
++
++		if(hash_table_entry->start == start)
++			return hash_table_entry->bytes;
++
++	return -1;
++}
++
++
++int read_fs_bytes(int fd, long long byte, int bytes, void *buff)
++{
++	off_t off = byte;
++	int res, count;
++
++	TRACE("read_bytes: reading from position 0x%llx, bytes %d\n", byte,
++		bytes);
++
++	if(lseek(fd, off, SEEK_SET) == -1) {
++		ERROR("Lseek failed because %s\n", strerror(errno));
++		return FALSE;
++	}
++
++	for(count = 0; count < bytes; count += res) {
++		res = read(fd, buff + count, bytes - count);
++		if(res < 1) {
++			if(res == 0) {
++				ERROR("Read on filesystem failed because "
++					"EOF\n");
++				return FALSE;
++			} else if(errno != EINTR) {
++				ERROR("Read on filesystem failed because %s\n",
++						strerror(errno));
++				return FALSE;
++			} else
++				res = 0;
++		}
++	}
++
++	return TRUE;
++}
++
++
++int read_block(int fd, long long start, long long *next, int expected,
++								void *block)
++{
++	unsigned short c_byte;
++	int offset = 2, res, compressed;
++	int outlen = expected ? expected : SQUASHFS_METADATA_SIZE;
++	
++	if(swap) {
++		if(read_fs_bytes(fd, start, 2, &c_byte) == FALSE)
++			goto failed;
++		c_byte = (c_byte >> 8) | ((c_byte & 0xff) << 8);
++	} else 
++		if(read_fs_bytes(fd, start, 2, &c_byte) == FALSE)
++			goto failed;
++
++	TRACE("read_block: block @0x%llx, %d %s bytes\n", start,
++		SQUASHFS_COMPRESSED_SIZE(c_byte), SQUASHFS_COMPRESSED(c_byte) ?
++		"compressed" : "uncompressed");
++
++	if(SQUASHFS_CHECK_DATA(sBlk.s.flags))
++		offset = 3;
++
++	compressed = SQUASHFS_COMPRESSED(c_byte);
++	c_byte = SQUASHFS_COMPRESSED_SIZE(c_byte);
++
++	/*
++	 * The block size should not be larger than
++	 * the uncompressed size (or max uncompressed size if
++	 * expected is 0)
++	 */
++	if(c_byte > outlen)
++		return 0;
++
++	if(compressed) {
++		char buffer[c_byte];
++		int error;
++
++		res = read_fs_bytes(fd, start + offset, c_byte, buffer);
++		if(res == FALSE)
++			goto failed;
++
++		res = compressor_uncompress(comp, block, buffer, c_byte,
++			outlen, &error);
++
++		if(res == -1) {
++			ERROR("%s uncompress failed with error code %d\n",
++				comp->name, error);
++			goto failed;
++		}
++	} else {
++		res = read_fs_bytes(fd, start + offset, c_byte, block);
++		if(res == FALSE)
++			goto failed;
++		res = c_byte;
++	}
++
++	if(next)
++		*next = start + offset + c_byte;
++
++	/*
++	 * if expected, then check the (uncompressed) return data
++	 * is of the expected size
++	 */
++	if(expected && expected != res)
++		return 0;
++	else
++		return res;
++
++failed:
++	ERROR("read_block: failed to read block @0x%llx\n", start);
++	return FALSE;
++}
++
++
++int read_data_block(long long start, unsigned int size, char *block)
++{
++	int error, res;
++	int c_byte = SQUASHFS_COMPRESSED_SIZE_BLOCK(size);
++
++	TRACE("read_data_block: block @0x%llx, %d %s bytes\n", start,
++		c_byte, SQUASHFS_COMPRESSED_BLOCK(size) ? "compressed" :
++		"uncompressed");
++
++	if(SQUASHFS_COMPRESSED_BLOCK(size)) {
++		if(read_fs_bytes(fd, start, c_byte, data) == FALSE)
++			goto failed;
++
++		res = compressor_uncompress(comp, block, data, c_byte,
++			block_size, &error);
++
++		if(res == -1) {
++			ERROR("%s uncompress failed with error code %d\n",
++				comp->name, error);
++			goto failed;
++		}
++
++		return res;
++	} else {
++		if(read_fs_bytes(fd, start, c_byte, block) == FALSE)
++			goto failed;
++
++		return c_byte;
++	}
++
++failed:
++	ERROR("read_data_block: failed to read block @0x%llx, size %d\n", start,
++		c_byte);
++	return FALSE;
++}
++
++
++int read_inode_table(long long start, long long end)
++{
++	int size = 0, bytes = 0, res;
++
++	TRACE("read_inode_table: start %lld, end %lld\n", start, end);
++
++	while(start < end) {
++		if(size - bytes < SQUASHFS_METADATA_SIZE) {
++			inode_table = realloc(inode_table, size +=
++				SQUASHFS_METADATA_SIZE);
++			if(inode_table == NULL) {
++				ERROR("Out of memory in read_inode_table");
++				goto failed;
++			}
++		}
++
++		add_entry(inode_table_hash, start, bytes);
++
++		res = read_block(fd, start, &start, 0, inode_table + bytes);
++		if(res == 0) {
++			ERROR("read_inode_table: failed to read block\n");
++			goto failed;
++		}
++		bytes += res;
++
++		/*
++		 * If this is not the last metadata block in the inode table
++		 * then it should be SQUASHFS_METADATA_SIZE in size.
++		 * Note, we can't use expected in read_block() above for this
++		 * because we don't know if this is the last block until
++		 * after reading.
++		 */
++		if(start != end && res != SQUASHFS_METADATA_SIZE) {
++			ERROR("read_inode_table: metadata block should be %d "
++				"bytes in length, it is %d bytes\n",
++				SQUASHFS_METADATA_SIZE, res);
++			
++			goto failed;
++		}
++	}
++
++	return TRUE;
++
++failed:
++	free(inode_table);
++	return FALSE;
++}
++
++
++int set_attributes(char *pathname, int mode, uid_t uid, gid_t guid, time_t time,
++	unsigned int xattr, unsigned int set_mode)
++{
++	struct utimbuf times = { time, time };
++
++	write_xattr(pathname, xattr);
++
++	if(utime(pathname, &times) == -1) {
++		ERROR("set_attributes: failed to set time on %s, because %s\n",
++			pathname, strerror(errno));
++		return FALSE;
++	}
++
++	if(root_process) {
++		if(chown(pathname, uid, guid) == -1) {
++			ERROR("set_attributes: failed to change uid and gids "
++				"on %s, because %s\n", pathname,
++				strerror(errno));
++			return FALSE;
++		}
++	} else
++		mode &= ~07000;
++
++	if((set_mode || (mode & 07000)) && chmod(pathname, (mode_t) mode) == -1) {
++		ERROR("set_attributes: failed to change mode %s, because %s\n",
++			pathname, strerror(errno));
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++
++int write_bytes(int fd, char *buff, int bytes)
++{
++	int res, count;
++
++	for(count = 0; count < bytes; count += res) {
++		res = write(fd, buff + count, bytes - count);
++		if(res == -1) {
++			if(errno != EINTR) {
++				ERROR("Write on output file failed because "
++					"%s\n", strerror(errno));
++				return -1;
++			}
++			res = 0;
++		}
++	}
++
++	return 0;
++}
++
++
++int lseek_broken = FALSE;
++char *zero_data = NULL;
++
++int write_block(int file_fd, char *buffer, int size, long long hole, int sparse)
++{
++	off_t off = hole;
++
++	if(hole) {
++		if(sparse && lseek_broken == FALSE) {
++			 int error = lseek(file_fd, off, SEEK_CUR);
++			 if(error == -1)
++				/* failed to seek beyond end of file */
++				lseek_broken = TRUE;
++		}
++
++		if((sparse == FALSE || lseek_broken) && zero_data == NULL) {
++			if((zero_data = malloc(block_size)) == NULL)
++				EXIT_UNSQUASH("write_block: failed to alloc "
++					"zero data block\n");
++			memset(zero_data, 0, block_size);
++		}
++
++		if(sparse == FALSE || lseek_broken) {
++			int blocks = (hole + block_size -1) / block_size;
++			int avail_bytes, i;
++			for(i = 0; i < blocks; i++, hole -= avail_bytes) {
++				avail_bytes = hole > block_size ? block_size :
++					hole;
++				if(write_bytes(file_fd, zero_data, avail_bytes)
++						== -1)
++					goto failure;
++			}
++		}
++	}
++
++	if(write_bytes(file_fd, buffer, size) == -1)
++		goto failure;
++
++	return TRUE;
++
++failure:
++	return FALSE;
++}
++
++
++pthread_mutex_t open_mutex = PTHREAD_MUTEX_INITIALIZER;
++pthread_cond_t open_empty = PTHREAD_COND_INITIALIZER;
++int open_unlimited, open_count;
++#define OPEN_FILE_MARGIN 10
++
++
++void open_init(int count)
++{
++	open_count = count;
++	open_unlimited = count == -1;
++}
++
++
++int open_wait(char *pathname, int flags, mode_t mode)
++{
++	if (!open_unlimited) {
++		pthread_mutex_lock(&open_mutex);
++		while (open_count == 0)
++			pthread_cond_wait(&open_empty, &open_mutex);
++		open_count --;
++		pthread_mutex_unlock(&open_mutex);
++	}
++
++	return open(pathname, flags, mode);
++}
++
++
++void close_wake(int fd)
++{
++	close(fd);
++
++	if (!open_unlimited) {
++		pthread_mutex_lock(&open_mutex);
++		open_count ++;
++		pthread_cond_signal(&open_empty);
++		pthread_mutex_unlock(&open_mutex);
++	}
++}
++
++
++void queue_file(char *pathname, int file_fd, struct inode *inode)
++{
++	struct squashfs_file *file = malloc(sizeof(struct squashfs_file));
++	if(file == NULL)
++		EXIT_UNSQUASH("queue_file: unable to malloc file\n");
++
++	file->fd = file_fd;
++	file->file_size = inode->data;
++	file->mode = inode->mode;
++	file->gid = inode->gid;
++	file->uid = inode->uid;
++	file->time = inode->time;
++	file->pathname = strdup(pathname);
++	file->blocks = inode->blocks + (inode->frag_bytes > 0);
++	file->sparse = inode->sparse;
++	file->xattr = inode->xattr;
++	queue_put(to_writer, file);
++}
++
++
++void queue_dir(char *pathname, struct dir *dir)
++{
++	struct squashfs_file *file = malloc(sizeof(struct squashfs_file));
++	if(file == NULL)
++		EXIT_UNSQUASH("queue_dir: unable to malloc file\n");
++
++	file->fd = -1;
++	file->mode = dir->mode;
++	file->gid = dir->guid;
++	file->uid = dir->uid;
++	file->time = dir->mtime;
++	file->pathname = strdup(pathname);
++	file->xattr = dir->xattr;
++	queue_put(to_writer, file);
++}
++
++
++int write_file(struct inode *inode, char *pathname)
++{
++	unsigned int file_fd, i;
++	unsigned int *block_list;
++	int file_end = inode->data / block_size;
++	long long start = inode->start;
++
++	TRACE("write_file: regular file, blocks %d\n", inode->blocks);
++
++	file_fd = open_wait(pathname, O_CREAT | O_WRONLY |
++		(force ? O_TRUNC : 0), (mode_t) inode->mode & 0777);
++	if(file_fd == -1) {
++		ERROR("write_file: failed to create file %s, because %s\n",
++			pathname, strerror(errno));
++		return FALSE;
++	}
++
++	block_list = malloc(inode->blocks * sizeof(unsigned int));
++	if(block_list == NULL)
++		EXIT_UNSQUASH("write_file: unable to malloc block list\n");
++
++	s_ops.read_block_list(block_list, inode->block_ptr, inode->blocks);
++
++	/*
++	 * the writer thread is queued a squashfs_file structure describing the
++ 	 * file.  If the file has one or more blocks or a fragment they are
++ 	 * queued separately (references to blocks in the cache).
++ 	 */
++	queue_file(pathname, file_fd, inode);
++
++	for(i = 0; i < inode->blocks; i++) {
++		int c_byte = SQUASHFS_COMPRESSED_SIZE_BLOCK(block_list[i]);
++		struct file_entry *block = malloc(sizeof(struct file_entry));
++
++		if(block == NULL)
++			EXIT_UNSQUASH("write_file: unable to malloc file\n");
++		block->offset = 0;
++		block->size = i == file_end ? inode->data & (block_size - 1) :
++			block_size;
++		if(block_list[i] == 0) /* sparse block */
++			block->buffer = NULL;
++		else {
++			block->buffer = cache_get(data_cache, start,
++				block_list[i]);
++			start += c_byte;
++		}
++		queue_put(to_writer, block);
++	}
++
++	if(inode->frag_bytes) {
++		int size;
++		long long start;
++		struct file_entry *block = malloc(sizeof(struct file_entry));
++
++		if(block == NULL)
++			EXIT_UNSQUASH("write_file: unable to malloc file\n");
++		s_ops.read_fragment(inode->fragment, &start, &size);
++		block->buffer = cache_get(fragment_cache, start, size);
++		block->offset = inode->offset;
++		block->size = inode->frag_bytes;
++		queue_put(to_writer, block);
++	}
++
++	free(block_list);
++	return TRUE;
++}
++
++
++int create_inode(char *pathname, struct inode *i)
++{
++	TRACE("create_inode: pathname %s\n", pathname);
++
++	if(created_inode[i->inode_number - 1]) {
++		TRACE("create_inode: hard link\n");
++		if(force)
++			unlink(pathname);
++
++		if(link(created_inode[i->inode_number - 1], pathname) == -1) {
++			ERROR("create_inode: failed to create hardlink, "
++				"because %s\n", strerror(errno));
++			return FALSE;
++		}
++
++		return TRUE;
++	}
++
++	switch(i->type) {
++		case SQUASHFS_FILE_TYPE:
++		case SQUASHFS_LREG_TYPE:
++			TRACE("create_inode: regular file, file_size %lld, "
++				"blocks %d\n", i->data, i->blocks);
++
++			if(write_file(i, pathname))
++				file_count ++;
++			break;
++		case SQUASHFS_SYMLINK_TYPE:
++		case SQUASHFS_LSYMLINK_TYPE:
++			TRACE("create_inode: symlink, symlink_size %lld\n",
++				i->data);
++
++			if(force)
++				unlink(pathname);
++
++			if(symlink(i->symlink, pathname) == -1) {
++				ERROR("create_inode: failed to create symlink "
++					"%s, because %s\n", pathname,
++					strerror(errno));
++				break;
++			}
++
++			write_xattr(pathname, i->xattr);
++	
++			if(root_process) {
++				if(lchown(pathname, i->uid, i->gid) == -1)
++					ERROR("create_inode: failed to change "
++						"uid and gids on %s, because "
++						"%s\n", pathname,
++						strerror(errno));
++			}
++
++			sym_count ++;
++			break;
++ 		case SQUASHFS_BLKDEV_TYPE:
++	 	case SQUASHFS_CHRDEV_TYPE:
++ 		case SQUASHFS_LBLKDEV_TYPE:
++	 	case SQUASHFS_LCHRDEV_TYPE: {
++			int chrdev = i->type == SQUASHFS_CHRDEV_TYPE;
++			TRACE("create_inode: dev, rdev 0x%llx\n", i->data);
++
++			if(root_process) {
++				if(force)
++					unlink(pathname);
++
++				if(mknod(pathname, chrdev ? S_IFCHR : S_IFBLK,
++						makedev((i->data >> 8) & 0xff,
++						i->data & 0xff)) == -1) {
++					ERROR("create_inode: failed to create "
++						"%s device %s, because %s\n",
++						chrdev ? "character" : "block",
++						pathname, strerror(errno));
++					break;
++				}
++				set_attributes(pathname, i->mode, i->uid,
++					i->gid, i->time, i->xattr, TRUE);
++				dev_count ++;
++			} else
++				ERROR("create_inode: could not create %s "
++					"device %s, because you're not "
++					"superuser!\n", chrdev ? "character" :
++					"block", pathname);
++			break;
++		}
++		case SQUASHFS_FIFO_TYPE:
++		case SQUASHFS_LFIFO_TYPE:
++			TRACE("create_inode: fifo\n");
++
++			if(force)
++				unlink(pathname);
++
++			if(mknod(pathname, S_IFIFO, 0) == -1) {
++				ERROR("create_inode: failed to create fifo %s, "
++					"because %s\n", pathname,
++					strerror(errno));
++				break;
++			}
++			set_attributes(pathname, i->mode, i->uid, i->gid,
++				i->time, i->xattr, TRUE);
++			fifo_count ++;
++			break;
++		case SQUASHFS_SOCKET_TYPE:
++		case SQUASHFS_LSOCKET_TYPE:
++			TRACE("create_inode: socket\n");
++			ERROR("create_inode: socket %s ignored\n", pathname);
++			break;
++		default:
++			ERROR("Unknown inode type %d in create_inode_table!\n",
++				i->type);
++			return FALSE;
++	}
++
++	created_inode[i->inode_number - 1] = strdup(pathname);
++
++	return TRUE;
++}
++
++
++int read_directory_table(long long start, long long end)
++{
++	int bytes = 0, size = 0, res;
++
++	TRACE("read_directory_table: start %lld, end %lld\n", start, end);
++
++	while(start < end) {
++		if(size - bytes < SQUASHFS_METADATA_SIZE) {
++			directory_table = realloc(directory_table, size +=
++				SQUASHFS_METADATA_SIZE);
++			if(directory_table == NULL) {
++				ERROR("Out of memory in "
++						"read_directory_table\n");
++				goto failed;
++			}
++		}
++
++		add_entry(directory_table_hash, start, bytes);
++
++		res = read_block(fd, start, &start, 0, directory_table + bytes);
++		if(res == 0) {
++			ERROR("read_directory_table: failed to read block\n");
++			goto failed;
++		}
++
++		bytes += res;
++
++		/*
++		 * If this is not the last metadata block in the directory table
++		 * then it should be SQUASHFS_METADATA_SIZE in size.
++		 * Note, we can't use expected in read_block() above for this
++		 * because we don't know if this is the last block until
++		 * after reading.
++		 */
++		if(start != end && res != SQUASHFS_METADATA_SIZE) {
++			ERROR("read_directory_table: metadata block "
++				"should be %d bytes in length, it is %d "
++				"bytes\n", SQUASHFS_METADATA_SIZE, res);
++			goto failed;
++		}
++	}
++
++	return TRUE;
++
++failed:
++	free(directory_table);
++	return FALSE;
++}
++
++
++int squashfs_readdir(struct dir *dir, char **name, unsigned int *start_block,
++unsigned int *offset, unsigned int *type)
++{
++	if(dir->cur_entry == dir->dir_count)
++		return FALSE;
++
++	*name = dir->dirs[dir->cur_entry].name;
++	*start_block = dir->dirs[dir->cur_entry].start_block;
++	*offset = dir->dirs[dir->cur_entry].offset;
++	*type = dir->dirs[dir->cur_entry].type;
++	dir->cur_entry ++;
++
++	return TRUE;
++}
++
++
++void squashfs_closedir(struct dir *dir)
++{
++	free(dir->dirs);
++	free(dir);
++}
++
++
++char *get_component(char *target, char **targname)
++{
++	char *start;
++
++	while(*target == '/')
++		target ++;
++
++	start = target;
++	while(*target != '/' && *target != '\0')
++		target ++;
++
++	*targname = strndup(start, target - start);
++
++	while(*target == '/')
++		target ++;
++
++	return target;
++}
++
++
++void free_path(struct pathname *paths)
++{
++	int i;
++
++	for(i = 0; i < paths->names; i++) {
++		if(paths->name[i].paths)
++			free_path(paths->name[i].paths);
++		free(paths->name[i].name);
++		if(paths->name[i].preg) {
++			regfree(paths->name[i].preg);
++			free(paths->name[i].preg);
++		}
++	}
++
++	free(paths);
++}
++
++
++struct pathname *add_path(struct pathname *paths, char *target, char *alltarget)
++{
++	char *targname;
++	int i, error;
++
++	TRACE("add_path: adding \"%s\" extract file\n", target);
++
++	target = get_component(target, &targname);
++
++	if(paths == NULL) {
++		paths = malloc(sizeof(struct pathname));
++		if(paths == NULL)
++			EXIT_UNSQUASH("failed to allocate paths\n");
++
++		paths->names = 0;
++		paths->name = NULL;
++	}
++
++	for(i = 0; i < paths->names; i++)
++		if(strcmp(paths->name[i].name, targname) == 0)
++			break;
++
++	if(i == paths->names) {
++		/*
++		 * allocate new name entry
++		 */
++		paths->names ++;
++		paths->name = realloc(paths->name, (i + 1) *
++			sizeof(struct path_entry));
++		if(paths->name == NULL)
++			EXIT_UNSQUASH("Out of memory in add_path\n");	
++		paths->name[i].name = targname;
++		paths->name[i].paths = NULL;
++		if(use_regex) {
++			paths->name[i].preg = malloc(sizeof(regex_t));
++			if(paths->name[i].preg == NULL)
++				EXIT_UNSQUASH("Out of memory in add_path\n");
++			error = regcomp(paths->name[i].preg, targname,
++				REG_EXTENDED|REG_NOSUB);
++			if(error) {
++				char str[1024]; /* overflow safe */
++
++				regerror(error, paths->name[i].preg, str, 1024);
++				EXIT_UNSQUASH("invalid regex %s in export %s, "
++					"because %s\n", targname, alltarget,
++					str);
++			}
++		} else
++			paths->name[i].preg = NULL;
++
++		if(target[0] == '\0')
++			/*
++			 * at leaf pathname component
++			*/
++			paths->name[i].paths = NULL;
++		else
++			/*
++			 * recurse adding child components
++			 */
++			paths->name[i].paths = add_path(NULL, target, alltarget);
++	} else {
++		/*
++		 * existing matching entry
++		 */
++		free(targname);
++
++		if(paths->name[i].paths == NULL) {
++			/*
++			 * No sub-directory which means this is the leaf
++			 * component of a pre-existing extract which subsumes
++			 * the extract currently being added, in which case stop
++			 * adding components
++			 */
++		} else if(target[0] == '\0') {
++			/*
++			 * at leaf pathname component and child components exist
++			 * from more specific extracts, delete as they're
++			 * subsumed by this extract
++			 */
++			free_path(paths->name[i].paths);
++			paths->name[i].paths = NULL;
++		} else
++			/*
++			 * recurse adding child components
++			 */
++			add_path(paths->name[i].paths, target, alltarget);
++	}
++
++	return paths;
++}
++
++
++struct pathnames *init_subdir()
++{
++	struct pathnames *new = malloc(sizeof(struct pathnames));
++	if(new == NULL)
++		EXIT_UNSQUASH("Out of memory in init_subdir\n");
++	new->count = 0;
++	return new;
++}
++
++
++struct pathnames *add_subdir(struct pathnames *paths, struct pathname *path)
++{
++	if(paths->count % PATHS_ALLOC_SIZE == 0) {
++		paths = realloc(paths, sizeof(struct pathnames *) +
++			(paths->count + PATHS_ALLOC_SIZE) *
++			sizeof(struct pathname *));
++		if(paths == NULL)
++			EXIT_UNSQUASH("Out of memory in add_subdir\n");
++	}
++
++	paths->path[paths->count++] = path;
++	return paths;
++}
++
++
++void free_subdir(struct pathnames *paths)
++{
++	free(paths);
++}
++
++
++int matches(struct pathnames *paths, char *name, struct pathnames **new)
++{
++	int i, n;
++
++	if(paths == NULL) {
++		*new = NULL;
++		return TRUE;
++	}
++
++	*new = init_subdir();
++
++	for(n = 0; n < paths->count; n++) {
++		struct pathname *path = paths->path[n];
++		for(i = 0; i < path->names; i++) {
++			int match = use_regex ?
++				regexec(path->name[i].preg, name, (size_t) 0,
++				NULL, 0) == 0 : fnmatch(path->name[i].name,
++				name, FNM_PATHNAME|FNM_PERIOD|FNM_EXTMATCH) ==
++				0;
++			if(match && path->name[i].paths == NULL)
++				/*
++				 * match on a leaf component, any subdirectories
++				 * will implicitly match, therefore return an
++				 * empty new search set
++				 */
++				goto empty_set;
++
++			if(match)
++				/*
++				 * match on a non-leaf component, add any
++				 * subdirectories to the new set of
++				 * subdirectories to scan for this name
++				 */
++				*new = add_subdir(*new, path->name[i].paths);
++		}
++	}
++
++	if((*new)->count == 0) {
++		/*
++		 * no matching names found, delete empty search set, and return
++		 * FALSE
++		 */
++		free_subdir(*new);
++		*new = NULL;
++		return FALSE;
++	}
++
++	/*
++	 * one or more matches with sub-directories found (no leaf matches),
++	 * return new search set and return TRUE
++	 */
++	return TRUE;
++
++empty_set:
++	/*
++	 * found matching leaf exclude, return empty search set and return TRUE
++	 */
++	free_subdir(*new);
++	*new = NULL;
++	return TRUE;
++}
++
++
++void pre_scan(char *parent_name, unsigned int start_block, unsigned int offset,
++	struct pathnames *paths)
++{
++	unsigned int type;
++	char *name;
++	struct pathnames *new;
++	struct inode *i;
++	struct dir *dir = s_ops.squashfs_opendir(start_block, offset, &i);
++
++	if(dir == NULL)
++		return;
++
++	while(squashfs_readdir(dir, &name, &start_block, &offset, &type)) {
++		struct inode *i;
++		char *pathname;
++		int res;
++
++		TRACE("pre_scan: name %s, start_block %d, offset %d, type %d\n",
++			name, start_block, offset, type);
++
++		if(!matches(paths, name, &new))
++			continue;
++
++		res = asprintf(&pathname, "%s/%s", parent_name, name);
++		if(res == -1)
++			EXIT_UNSQUASH("asprintf failed in dir_scan\n");
++
++		if(type == SQUASHFS_DIR_TYPE)
++			pre_scan(parent_name, start_block, offset, new);
++		else if(new == NULL) {
++			if(type == SQUASHFS_FILE_TYPE ||
++					type == SQUASHFS_LREG_TYPE) {
++				i = s_ops.read_inode(start_block, offset);
++				if(created_inode[i->inode_number - 1] == NULL) {
++					created_inode[i->inode_number - 1] =
++						(char *) i;
++					total_blocks += (i->data +
++						(block_size - 1)) >> block_log;
++				}
++				total_files ++;
++			}
++			total_inodes ++;
++		}
++
++		free_subdir(new);
++		free(pathname);
++	}
++
++	squashfs_closedir(dir);
++}
++
++
++void dir_scan(char *parent_name, unsigned int start_block, unsigned int offset,
++	struct pathnames *paths)
++{
++	unsigned int type;
++	char *name;
++	struct pathnames *new;
++	struct inode *i;
++	struct dir *dir = s_ops.squashfs_opendir(start_block, offset, &i);
++
++	if(dir == NULL) {
++		ERROR("dir_scan: failed to read directory %s, skipping\n",
++			parent_name);
++		return;
++	}
++
++	if(lsonly || info)
++		print_filename(parent_name, i);
++
++	if(!lsonly) {
++		/*
++		 * Make directory with default User rwx permissions rather than
++		 * the permissions from the filesystem, as these may not have
++		 * write/execute permission.  These are fixed up later in
++		 * set_attributes().
++		 */
++		int res = mkdir(parent_name, S_IRUSR|S_IWUSR|S_IXUSR);
++		if(res == -1) {
++			/*
++			 * Skip directory if mkdir fails, unless we're
++			 * forcing and the error is -EEXIST
++			 */
++			if(!force || errno != EEXIST) {
++				ERROR("dir_scan: failed to make directory %s, "
++					"because %s\n", parent_name,
++					strerror(errno));
++				squashfs_closedir(dir);
++				return;
++			} 
++
++			/*
++			 * Try to change permissions of existing directory so
++			 * that we can write to it
++			 */
++			res = chmod(parent_name, S_IRUSR|S_IWUSR|S_IXUSR);
++			if (res == -1)
++				ERROR("dir_scan: failed to change permissions "
++					"for directory %s, because %s\n",
++					parent_name, strerror(errno));
++		}
++	}
++
++	while(squashfs_readdir(dir, &name, &start_block, &offset, &type)) {
++		char *pathname;
++		int res;
++
++		TRACE("dir_scan: name %s, start_block %d, offset %d, type %d\n",
++			name, start_block, offset, type);
++
++
++		if(!matches(paths, name, &new))
++			continue;
++
++		res = asprintf(&pathname, "%s/%s", parent_name, name);
++		if(res == -1)
++			EXIT_UNSQUASH("asprintf failed in dir_scan\n");
++
++		if(type == SQUASHFS_DIR_TYPE) {
++			dir_scan(pathname, start_block, offset, new);
++			free(pathname);
++		} else if(new == NULL) {
++			update_info(pathname);
++
++			i = s_ops.read_inode(start_block, offset);
++
++			if(lsonly || info)
++				print_filename(pathname, i);
++
++			if(!lsonly)
++				create_inode(pathname, i);
++
++			if(i->type == SQUASHFS_SYMLINK_TYPE ||
++					i->type == SQUASHFS_LSYMLINK_TYPE)
++				free(i->symlink);
++		} else
++			free(pathname);
++
++		free_subdir(new);
++	}
++
++	if(!lsonly)
++		queue_dir(parent_name, dir);
++
++	squashfs_closedir(dir);
++	dir_count ++;
++}
++
++
++void squashfs_stat(char *source)
++{
++	time_t mkfs_time = (time_t) sBlk.s.mkfs_time;
++	char *mkfs_str = ctime(&mkfs_time);
++
++#if __BYTE_ORDER == __BIG_ENDIAN
++	printf("Found a valid %sSQUASHFS %d:%d superblock on %s.\n",
++		sBlk.s.s_major == 4 ? "" : swap ? "little endian " :
++		"big endian ", sBlk.s.s_major, sBlk.s.s_minor, source);
++#else
++	printf("Found a valid %sSQUASHFS %d:%d superblock on %s.\n",
++		sBlk.s.s_major == 4 ? "" : swap ? "big endian " :
++		"little endian ", sBlk.s.s_major, sBlk.s.s_minor, source);
++#endif
++
++	printf("Creation or last append time %s", mkfs_str ? mkfs_str :
++		"failed to get time\n");
++	printf("Filesystem size %.2f Kbytes (%.2f Mbytes)\n",
++		sBlk.s.bytes_used / 1024.0, sBlk.s.bytes_used /
++		(1024.0 * 1024.0));
++
++	if(sBlk.s.s_major == 4) {
++		printf("Compression %s\n", comp->name);
++
++		if(SQUASHFS_COMP_OPTS(sBlk.s.flags)) {
++			char buffer[SQUASHFS_METADATA_SIZE] __attribute__ ((aligned));
++			int bytes;
++
++			bytes = read_block(fd, sizeof(sBlk.s), NULL, 0, buffer);
++			if(bytes == 0) {
++				ERROR("Failed to read compressor options\n");
++				return;
++			}
++
++			compressor_display_options(comp, buffer, bytes);
++		}
++	}
++
++	printf("Block size %d\n", sBlk.s.block_size);
++	printf("Filesystem is %sexportable via NFS\n",
++		SQUASHFS_EXPORTABLE(sBlk.s.flags) ? "" : "not ");
++	printf("Inodes are %scompressed\n",
++		SQUASHFS_UNCOMPRESSED_INODES(sBlk.s.flags) ? "un" : "");
++	printf("Data is %scompressed\n",
++		SQUASHFS_UNCOMPRESSED_DATA(sBlk.s.flags) ? "un" : "");
++
++	if(sBlk.s.s_major > 1) {
++		if(SQUASHFS_NO_FRAGMENTS(sBlk.s.flags))
++			printf("Fragments are not stored\n");
++		else {
++			printf("Fragments are %scompressed\n",
++				SQUASHFS_UNCOMPRESSED_FRAGMENTS(sBlk.s.flags) ?
++				"un" : "");
++			printf("Always-use-fragments option is %sspecified\n",
++				SQUASHFS_ALWAYS_FRAGMENTS(sBlk.s.flags) ? "" :
++				"not ");
++		}
++	}
++
++	if(sBlk.s.s_major == 4) {
++		if(SQUASHFS_NO_XATTRS(sBlk.s.flags))
++			printf("Xattrs are not stored\n");
++		else
++			printf("Xattrs are %scompressed\n",
++				SQUASHFS_UNCOMPRESSED_XATTRS(sBlk.s.flags) ?
++				"un" : "");
++	}
++
++	if(sBlk.s.s_major < 4)
++			printf("Check data is %spresent in the filesystem\n",
++				SQUASHFS_CHECK_DATA(sBlk.s.flags) ? "" :
++				"not ");
++
++	if(sBlk.s.s_major > 1)
++		printf("Duplicates are %sremoved\n",
++			SQUASHFS_DUPLICATES(sBlk.s.flags) ? "" : "not ");
++	else
++		printf("Duplicates are removed\n");
++
++	if(sBlk.s.s_major > 1)
++		printf("Number of fragments %d\n", sBlk.s.fragments);
++
++	printf("Number of inodes %d\n", sBlk.s.inodes);
++
++	if(sBlk.s.s_major == 4)
++		printf("Number of ids %d\n", sBlk.s.no_ids);
++	else {
++		printf("Number of uids %d\n", sBlk.no_uids);
++		printf("Number of gids %d\n", sBlk.no_guids);
++	}
++
++	TRACE("sBlk.s.inode_table_start 0x%llx\n", sBlk.s.inode_table_start);
++	TRACE("sBlk.s.directory_table_start 0x%llx\n",
++		sBlk.s.directory_table_start);
++
++	if(sBlk.s.s_major > 1)
++		TRACE("sBlk.s.fragment_table_start 0x%llx\n\n",
++			sBlk.s.fragment_table_start);
++
++	if(sBlk.s.s_major > 2)
++		TRACE("sBlk.s.lookup_table_start 0x%llx\n\n",
++			sBlk.s.lookup_table_start);
++
++	if(sBlk.s.s_major == 4) {
++		TRACE("sBlk.s.id_table_start 0x%llx\n", sBlk.s.id_table_start);
++		TRACE("sBlk.s.xattr_id_table_start 0x%llx\n",
++			sBlk.s.xattr_id_table_start);
++	} else {
++		TRACE("sBlk.uid_start 0x%llx\n", sBlk.uid_start);
++		TRACE("sBlk.guid_start 0x%llx\n", sBlk.guid_start);
++	}
++}
++
++
++int check_compression(struct compressor *comp)
++{
++	int res, bytes = 0;
++	char buffer[SQUASHFS_METADATA_SIZE] __attribute__ ((aligned));
++
++	if(!comp->supported) {
++		ERROR("Filesystem uses %s compression, this is "
++			"unsupported by this version\n", comp->name);
++		ERROR("Decompressors available:\n");
++		display_compressors("", "");
++		return 0;
++	}
++
++	/*
++	 * Read compression options from disk if present, and pass to
++	 * the compressor to ensure we know how to decompress a filesystem
++	 * compressed with these compression options.
++	 *
++	 * Note, even if there is no compression options we still call the
++	 * compressor because some compression options may be mandatory
++	 * for some compressors.
++	 */
++	if(SQUASHFS_COMP_OPTS(sBlk.s.flags)) {
++		bytes = read_block(fd, sizeof(sBlk.s), NULL, 0, buffer);
++		if(bytes == 0) {
++			ERROR("Failed to read compressor options\n");
++			return 0;
++		}
++	}
++
++	res = compressor_check_options(comp, sBlk.s.block_size, buffer, bytes);
++
++	return res != -1;
++}
++
++
++int read_super(char *source)
++{
++	squashfs_super_block_3 sBlk_3;
++	struct squashfs_super_block sBlk_4;
++
++	/*
++	 * Try to read a Squashfs 4 superblock
++	 */
++	read_fs_bytes(fd, SQUASHFS_START, sizeof(struct squashfs_super_block),
++		&sBlk_4);
++	swap = sBlk_4.s_magic != SQUASHFS_MAGIC;
++	SQUASHFS_INSWAP_SUPER_BLOCK(&sBlk_4);
++
++	if(sBlk_4.s_magic == SQUASHFS_MAGIC && sBlk_4.s_major == 4 &&
++			sBlk_4.s_minor == 0) {
++		s_ops.squashfs_opendir = squashfs_opendir_4;
++		s_ops.read_fragment = read_fragment_4;
++		s_ops.read_fragment_table = read_fragment_table_4;
++		s_ops.read_block_list = read_block_list_2;
++		s_ops.read_inode = read_inode_4;
++		s_ops.read_uids_guids = read_uids_guids_4;
++		memcpy(&sBlk, &sBlk_4, sizeof(sBlk_4));
++
++		/*
++		 * Check the compression type
++		 */
++		comp = lookup_compressor_id(sBlk.s.compression);
++		return TRUE;
++	}
++
++	/*
++ 	 * Not a Squashfs 4 superblock, try to read a squashfs 3 superblock
++ 	 * (compatible with 1 and 2 filesystems)
++ 	 */
++	read_fs_bytes(fd, SQUASHFS_START, sizeof(squashfs_super_block_3),
++		&sBlk_3);
++
++	/*
++	 * Check it is a SQUASHFS superblock
++	 */
++	swap = 0;
++	if(sBlk_3.s_magic != SQUASHFS_MAGIC) {
++		if(sBlk_3.s_magic == SQUASHFS_MAGIC_SWAP) {
++			squashfs_super_block_3 sblk;
++			ERROR("Reading a different endian SQUASHFS filesystem "
++				"on %s\n", source);
++			SQUASHFS_SWAP_SUPER_BLOCK_3(&sblk, &sBlk_3);
++			memcpy(&sBlk_3, &sblk, sizeof(squashfs_super_block_3));
++			swap = 1;
++		} else  {
++			ERROR("Can't find a SQUASHFS superblock on %s\n",
++				source);
++			goto failed_mount;
++		}
++	}
++
++	sBlk.s.s_magic = sBlk_3.s_magic;
++	sBlk.s.inodes = sBlk_3.inodes;
++	sBlk.s.mkfs_time = sBlk_3.mkfs_time;
++	sBlk.s.block_size = sBlk_3.block_size;
++	sBlk.s.fragments = sBlk_3.fragments;
++	sBlk.s.block_log = sBlk_3.block_log;
++	sBlk.s.flags = sBlk_3.flags;
++	sBlk.s.s_major = sBlk_3.s_major;
++	sBlk.s.s_minor = sBlk_3.s_minor;
++	sBlk.s.root_inode = sBlk_3.root_inode;
++	sBlk.s.bytes_used = sBlk_3.bytes_used;
++	sBlk.s.inode_table_start = sBlk_3.inode_table_start;
++	sBlk.s.directory_table_start = sBlk_3.directory_table_start;
++	sBlk.s.fragment_table_start = sBlk_3.fragment_table_start;
++	sBlk.s.lookup_table_start = sBlk_3.lookup_table_start;
++	sBlk.no_uids = sBlk_3.no_uids;
++	sBlk.no_guids = sBlk_3.no_guids;
++	sBlk.uid_start = sBlk_3.uid_start;
++	sBlk.guid_start = sBlk_3.guid_start;
++	sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
++
++	/* Check the MAJOR & MINOR versions */
++	if(sBlk.s.s_major == 1 || sBlk.s.s_major == 2) {
++		sBlk.s.bytes_used = sBlk_3.bytes_used_2;
++		sBlk.uid_start = sBlk_3.uid_start_2;
++		sBlk.guid_start = sBlk_3.guid_start_2;
++		sBlk.s.inode_table_start = sBlk_3.inode_table_start_2;
++		sBlk.s.directory_table_start = sBlk_3.directory_table_start_2;
++		
++		if(sBlk.s.s_major == 1) {
++			sBlk.s.block_size = sBlk_3.block_size_1;
++			sBlk.s.fragment_table_start = sBlk.uid_start;
++			s_ops.squashfs_opendir = squashfs_opendir_1;
++			s_ops.read_fragment_table = read_fragment_table_1;
++			s_ops.read_block_list = read_block_list_1;
++			s_ops.read_inode = read_inode_1;
++			s_ops.read_uids_guids = read_uids_guids_1;
++		} else {
++			sBlk.s.fragment_table_start =
++				sBlk_3.fragment_table_start_2;
++			s_ops.squashfs_opendir = squashfs_opendir_1;
++			s_ops.read_fragment = read_fragment_2;
++			s_ops.read_fragment_table = read_fragment_table_2;
++			s_ops.read_block_list = read_block_list_2;
++			s_ops.read_inode = read_inode_2;
++			s_ops.read_uids_guids = read_uids_guids_1;
++		}
++	} else if(sBlk.s.s_major == 3) {
++		s_ops.squashfs_opendir = squashfs_opendir_3;
++		s_ops.read_fragment = read_fragment_3;
++		s_ops.read_fragment_table = read_fragment_table_3;
++		s_ops.read_block_list = read_block_list_2;
++		s_ops.read_inode = read_inode_3;
++		s_ops.read_uids_guids = read_uids_guids_1;
++	} else {
++		ERROR("Filesystem on %s is (%d:%d), ", source, sBlk.s.s_major,
++			sBlk.s.s_minor);
++		ERROR("which is a later filesystem version than I support!\n");
++		goto failed_mount;
++	}
++
++	/*
++	 * 1.x, 2.x and 3.x filesystems use gzip compression.
++	 */
++	comp = lookup_compressor("gzip");
++	return TRUE;
++
++failed_mount:
++	return FALSE;
++}
++
++
++struct pathname *process_extract_files(struct pathname *path, char *filename)
++{
++	FILE *fd;
++	char buffer[MAX_LINE + 1]; /* overflow safe */
++	char *name;
++
++	fd = fopen(filename, "r");
++	if(fd == NULL)
++		EXIT_UNSQUASH("Failed to open extract file \"%s\" because %s\n",
++			filename, strerror(errno));
++
++	while(fgets(name = buffer, MAX_LINE + 1, fd) != NULL) {
++		int len = strlen(name);
++
++		if(len == MAX_LINE && name[len - 1] != '\n')
++			/* line too large */
++			EXIT_UNSQUASH("Line too long when reading "
++				"extract file \"%s\", larger than %d "
++				"bytes\n", filename, MAX_LINE);
++
++		/*
++		 * Remove '\n' terminator if it exists (the last line
++		 * in the file may not be '\n' terminated)
++		 */
++		if(len && name[len - 1] == '\n')
++			name[len - 1] = '\0';
++
++		/* Skip any leading whitespace */
++		while(isspace(*name))
++			name ++;
++
++		/* if comment line, skip */
++		if(*name == '#')
++			continue;
++
++		/* check for initial backslash, to accommodate
++		 * filenames with leading space or leading # character
++		 */
++		if(*name == '\\')
++			name ++;
++
++		/* if line is now empty after skipping characters, skip it */
++		if(*name == '\0')
++			continue;
++
++		path = add_path(path, name, name);
++	}
++
++	if(ferror(fd))
++		EXIT_UNSQUASH("Reading extract file \"%s\" failed because %s\n",
++			filename, strerror(errno));
++
++	fclose(fd);
++	return path;
++}
++		
++
++/*
++ * reader thread.  This thread processes read requests queued by the
++ * cache_get() routine.
++ */
++void *reader(void *arg)
++{
++	while(1) {
++		struct cache_entry *entry = queue_get(to_reader);
++		int res = read_fs_bytes(fd, entry->block,
++			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size),
++			entry->data);
++
++		if(res && SQUASHFS_COMPRESSED_BLOCK(entry->size))
++			/*
++			 * queue successfully read block to the inflate
++			 * thread(s) for further processing
++ 			 */
++			queue_put(to_inflate, entry);
++		else
++			/*
++			 * block has either been successfully read and is
++			 * uncompressed, or an error has occurred, clear pending
++			 * flag, set error appropriately, and wake up any
++			 * threads waiting on this buffer
++			 */
++			cache_block_ready(entry, !res);
++	}
++}
++
++
++/*
++ * writer thread.  This processes file write requests queued by the
++ * write_file() routine.
++ */
++void *writer(void *arg)
++{
++	int i;
++
++	while(1) {
++		struct squashfs_file *file = queue_get(to_writer);
++		int file_fd;
++		long long hole = 0;
++		int failed = FALSE;
++		int error;
++
++		if(file == NULL) {
++			queue_put(from_writer, NULL);
++			continue;
++		} else if(file->fd == -1) {
++			/* write attributes for directory file->pathname */
++			set_attributes(file->pathname, file->mode, file->uid,
++				file->gid, file->time, file->xattr, TRUE);
++			free(file->pathname);
++			free(file);
++			continue;
++		}
++
++		TRACE("writer: regular file, blocks %d\n", file->blocks);
++
++		file_fd = file->fd;
++
++		for(i = 0; i < file->blocks; i++, cur_blocks ++) {
++			struct file_entry *block = queue_get(to_writer);
++
++			if(block->buffer == 0) { /* sparse file */
++				hole += block->size;
++				free(block);
++				continue;
++			}
++
++			cache_block_wait(block->buffer);
++
++			if(block->buffer->error)
++				failed = TRUE;
++
++			if(failed)
++				continue;
++
++			error = write_block(file_fd, block->buffer->data +
++				block->offset, block->size, hole, file->sparse);
++
++			if(error == FALSE) {
++				ERROR("writer: failed to write data block %d\n",
++					i);
++				failed = TRUE;
++			}
++
++			hole = 0;
++			cache_block_put(block->buffer);
++			free(block);
++		}
++
++		if(hole && failed == FALSE) {
++			/*
++			 * corner case for hole extending to end of file
++			 */
++			if(file->sparse == FALSE ||
++					lseek(file_fd, hole, SEEK_CUR) == -1) {
++				/*
++				 * for files which we don't want to write
++				 * sparsely, or for broken lseeks which cannot
++				 * seek beyond end of file, write_block will do
++				 * the right thing
++				 */
++				hole --;
++				if(write_block(file_fd, "\0", 1, hole,
++						file->sparse) == FALSE) {
++					ERROR("writer: failed to write sparse "
++						"data block\n");
++					failed = TRUE;
++				}
++			} else if(ftruncate(file_fd, file->file_size) == -1) {
++				ERROR("writer: failed to write sparse data "
++					"block\n");
++				failed = TRUE;
++			}
++		}
++
++		close_wake(file_fd);
++		if(failed == FALSE)
++			set_attributes(file->pathname, file->mode, file->uid,
++				file->gid, file->time, file->xattr, force);
++		else {
++			ERROR("Failed to write %s, skipping\n", file->pathname);
++			unlink(file->pathname);
++		}
++		free(file->pathname);
++		free(file);
++
++	}
++}
++
++
++/*
++ * decompress thread.  This decompresses buffers queued by the read thread
++ */
++void *inflator(void *arg)
++{
++	char tmp[block_size];
++
++	while(1) {
++		struct cache_entry *entry = queue_get(to_inflate);
++		int error, res;
++
++		res = compressor_uncompress(comp, tmp, entry->data,
++			SQUASHFS_COMPRESSED_SIZE_BLOCK(entry->size), block_size,
++			&error);
++
++		if(res == -1)
++			ERROR("%s uncompress failed with error code %d\n",
++				comp->name, error);
++		else
++			memcpy(entry->data, tmp, res);
++
++		/*
++		 * block has been either successfully decompressed, or an error
++ 		 * occurred, clear pending flag, set error appropriately and
++ 		 * wake up any threads waiting on this block
++ 		 */ 
++		cache_block_ready(entry, res == -1);
++	}
++}
++
++
++void *progress_thread(void *arg)
++{
++	struct timespec requested_time, remaining;
++	struct itimerval itimerval;
++	struct winsize winsize;
++
++	if(ioctl(1, TIOCGWINSZ, &winsize) == -1) {
++		if(isatty(STDOUT_FILENO))
++			ERROR("TIOCGWINSZ ioctl failed, defaulting to 80 "
++				"columns\n");
++		columns = 80;
++	} else
++		columns = winsize.ws_col;
++	signal(SIGWINCH, sigwinch_handler);
++	signal(SIGALRM, sigalrm_handler);
++
++	itimerval.it_value.tv_sec = 0;
++	itimerval.it_value.tv_usec = 250000;
++	itimerval.it_interval.tv_sec = 0;
++	itimerval.it_interval.tv_usec = 250000;
++	setitimer(ITIMER_REAL, &itimerval, NULL);
++
++	requested_time.tv_sec = 0;
++	requested_time.tv_nsec = 250000000;
++
++	while(1) {
++		int res = nanosleep(&requested_time, &remaining);
++
++		if(res == -1 && errno != EINTR)
++			EXIT_UNSQUASH("nanosleep failed in progress thread\n");
++
++		if(progress_enabled) {
++			pthread_mutex_lock(&screen_mutex);
++			progress_bar(sym_count + dev_count +
++				fifo_count + cur_blocks, total_inodes -
++				total_files + total_blocks, columns);
++			pthread_mutex_unlock(&screen_mutex);
++		}
++	}
++}
++
++
++void initialise_threads(int fragment_buffer_size, int data_buffer_size)
++{
++	struct rlimit rlim;
++	int i, max_files, res;
++	sigset_t sigmask, old_mask;
++
++	/* block SIGQUIT and SIGHUP, these are handled by the info thread */
++	sigemptyset(&sigmask);
++	sigaddset(&sigmask, SIGQUIT);
++	sigaddset(&sigmask, SIGHUP);
++	if(pthread_sigmask(SIG_BLOCK, &sigmask, NULL) == -1)
++		EXIT_UNSQUASH("Failed to set signal mask in initialise_threads"
++			"\n");
++
++	/*
++	 * temporarily block these signals so the created sub-threads will
++	 * ignore them, ensuring the main thread handles them
++	 */
++	sigemptyset(&sigmask);
++	sigaddset(&sigmask, SIGINT);
++	sigaddset(&sigmask, SIGTERM);
++	if(pthread_sigmask(SIG_BLOCK, &sigmask, &old_mask) == -1)
++		EXIT_UNSQUASH("Failed to set signal mask in initialise_threads"
++			"\n");
++
++	if(processors == -1) {
++#ifndef linux
++		int mib[2];
++		size_t len = sizeof(processors);
++
++		mib[0] = CTL_HW;
++#ifdef HW_AVAILCPU
++		mib[1] = HW_AVAILCPU;
++#else
++		mib[1] = HW_NCPU;
++#endif
++
++		if(sysctl(mib, 2, &processors, &len, NULL, 0) == -1) {
++			ERROR("Failed to get number of available processors.  "
++				"Defaulting to 1\n");
++			processors = 1;
++		}
++#else
++		processors = sysconf(_SC_NPROCESSORS_ONLN);
++#endif
++	}
++
++	if(add_overflow(processors, 3) ||
++			multiply_overflow(processors + 3, sizeof(pthread_t)))
++		EXIT_UNSQUASH("Processors too large\n");
++
++	thread = malloc((3 + processors) * sizeof(pthread_t));
++	if(thread == NULL)
++		EXIT_UNSQUASH("Out of memory allocating thread descriptors\n");
++	inflator_thread = &thread[3];
++
++	/*
++	 * dimensioning the to_reader and to_inflate queues.  The size of
++	 * these queues is directly related to the amount of block
++	 * read-ahead possible.  To_reader queues block read requests to
++	 * the reader thread and to_inflate queues block decompression
++	 * requests to the inflate thread(s) (once the block has been read by
++	 * the reader thread).  The amount of read-ahead is determined by
++	 * the combined size of the data_block and fragment caches which
++	 * determine the total number of blocks which can be "in flight"
++	 * at any one time (either being read or being decompressed)
++	 *
++	 * The maximum file open limit, however, affects the read-ahead
++	 * possible, in that for normal sizes of the fragment and data block
++	 * caches, where the incoming files have few data blocks or one fragment
++	 * only, the file open limit is likely to be reached before the
++	 * caches are full.  This means the worst case sizing of the combined
++	 * sizes of the caches is unlikely to ever be necessary.  However, is is
++	 * obvious read-ahead up to the data block cache size is always possible
++	 * irrespective of the file open limit, because a single file could
++	 * contain that number of blocks.
++	 *
++	 * Choosing the size as "file open limit + data block cache size" seems
++	 * to be a reasonable estimate.  We can reasonably assume the maximum
++	 * likely read-ahead possible is data block cache size + one fragment
++	 * per open file.
++	 *
++	 * dimensioning the to_writer queue.  The size of this queue is
++	 * directly related to the amount of block read-ahead possible.
++	 * However, unlike the to_reader and to_inflate queues, this is
++	 * complicated by the fact the to_writer queue not only contains
++	 * entries for fragments and data_blocks but it also contains
++	 * file entries, one per open file in the read-ahead.
++	 *
++	 * Choosing the size as "2 * (file open limit) +
++	 * data block cache size" seems to be a reasonable estimate.
++	 * We can reasonably assume the maximum likely read-ahead possible
++	 * is data block cache size + one fragment per open file, and then
++	 * we will have a file_entry for each open file.
++	 */
++	res = getrlimit(RLIMIT_NOFILE, &rlim);
++	if (res == -1) {
++		ERROR("failed to get open file limit!  Defaulting to 1\n");
++		rlim.rlim_cur = 1;
++	}
++
++	if (rlim.rlim_cur != RLIM_INFINITY) {
++		/*
++		 * leave OPEN_FILE_MARGIN free (rlim_cur includes fds used by
++		 * stdin, stdout, stderr and filesystem fd
++		 */
++		if (rlim.rlim_cur <= OPEN_FILE_MARGIN)
++			/* no margin, use minimum possible */
++			max_files = 1;
++		else
++			max_files = rlim.rlim_cur - OPEN_FILE_MARGIN;
++	} else
++		max_files = -1;
++
++	/* set amount of available files for use by open_wait and close_wake */
++	open_init(max_files);
++
++	/*
++	 * allocate to_reader, to_inflate and to_writer queues.  Set based on
++	 * open file limit and cache size, unless open file limit is unlimited,
++	 * in which case set purely based on cache limits
++	 *
++	 * In doing so, check that the user supplied values do not overflow
++	 * a signed int
++	 */
++	if (max_files != -1) {
++		if(add_overflow(data_buffer_size, max_files) ||
++				add_overflow(data_buffer_size, max_files * 2))
++			EXIT_UNSQUASH("Data queue size is too large\n");
++
++		to_reader = queue_init(max_files + data_buffer_size);
++		to_inflate = queue_init(max_files + data_buffer_size);
++		to_writer = queue_init(max_files * 2 + data_buffer_size);
++	} else {
++		int all_buffers_size;
++
++		if(add_overflow(fragment_buffer_size, data_buffer_size))
++			EXIT_UNSQUASH("Data and fragment queues combined are"
++							" too large\n");
++
++		all_buffers_size = fragment_buffer_size + data_buffer_size;
++
++		if(add_overflow(all_buffers_size, all_buffers_size))
++			EXIT_UNSQUASH("Data and fragment queues combined are"
++							" too large\n");
++
++		to_reader = queue_init(all_buffers_size);
++		to_inflate = queue_init(all_buffers_size);
++		to_writer = queue_init(all_buffers_size * 2);
++	}
++
++	from_writer = queue_init(1);
++
++	fragment_cache = cache_init(block_size, fragment_buffer_size);
++	data_cache = cache_init(block_size, data_buffer_size);
++	pthread_create(&thread[0], NULL, reader, NULL);
++	pthread_create(&thread[1], NULL, writer, NULL);
++	pthread_create(&thread[2], NULL, progress_thread, NULL);
++	init_info();
++	pthread_mutex_init(&fragment_mutex, NULL);
++
++	for(i = 0; i < processors; i++) {
++		if(pthread_create(&inflator_thread[i], NULL, inflator, NULL) !=
++				 0)
++			EXIT_UNSQUASH("Failed to create thread\n");
++	}
++
++	printf("Parallel unsquashfs: Using %d processor%s\n", processors,
++			processors == 1 ? "" : "s");
++
++	if(pthread_sigmask(SIG_SETMASK, &old_mask, NULL) == -1)
++		EXIT_UNSQUASH("Failed to set signal mask in initialise_threads"
++			"\n");
++}
++
++
++void enable_progress_bar()
++{
++	pthread_mutex_lock(&screen_mutex);
++	progress_enabled = progress;
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++
++void disable_progress_bar()
++{
++	pthread_mutex_lock(&screen_mutex);
++	if(progress_enabled) {
++		progress_bar(sym_count + dev_count + fifo_count + cur_blocks,
++			total_inodes - total_files + total_blocks, columns);
++		printf("\n");
++	}
++	progress_enabled = FALSE;
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++
++void progressbar_error(char *fmt, ...)
++{
++	va_list ap;
++
++	pthread_mutex_lock(&screen_mutex);
++
++	if(progress_enabled)
++		fprintf(stderr, "\n");
++
++	va_start(ap, fmt);
++	vfprintf(stderr, fmt, ap);
++	va_end(ap);
++
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++
++void progressbar_info(char *fmt, ...)
++{
++	va_list ap;
++
++	pthread_mutex_lock(&screen_mutex);
++
++	if(progress_enabled)
++		printf("\n");
++
++	va_start(ap, fmt);
++	vprintf(fmt, ap);
++	va_end(ap);
++
++	pthread_mutex_unlock(&screen_mutex);
++}
++
++void progress_bar(long long current, long long max, int columns)
++{
++	char rotate_list[] = { '|', '/', '-', '\\' };
++	int max_digits, used, hashes, spaces;
++	static int tty = -1;
++
++	if(max == 0)
++		return;
++
++	max_digits = floor(log10(max)) + 1;
++	used = max_digits * 2 + 11;
++	hashes = (current * (columns - used)) / max;
++	spaces = columns - used - hashes;
++
++	if((current > max) || (columns - used < 0))
++		return;
++
++	if(tty == -1)
++		tty = isatty(STDOUT_FILENO);
++	if(!tty) {
++		static long long previous = -1;
++
++		/*
++		 * Updating much more frequently than this results in huge
++		 * log files.
++		 */
++		if((current % 100) != 0 && current != max)
++			return;
++		/* Don't update just to rotate the spinner. */
++		if(current == previous)
++			return;
++		previous = current;
++	}
++
++	printf("\r[");
++
++	while (hashes --)
++		putchar('=');
++
++	putchar(rotate_list[rotate]);
++
++	while(spaces --)
++		putchar(' ');
++
++	printf("] %*lld/%*lld", max_digits, current, max_digits, max);
++	printf(" %3lld%%", current * 100 / max);
++	fflush(stdout);
++}
++
++
++int parse_number(char *arg, int *res)
++{
++	char *b;
++	long number = strtol(arg, &b, 10);
++
++	/* check for trailing junk after number */
++	if(*b != '\0')
++		return 0;
++
++	/*
++	 * check for strtol underflow or overflow in conversion.
++	 * Note: strtol can validly return LONG_MIN and LONG_MAX
++	 * if the user entered these values, but, additional code
++	 * to distinguish this scenario is unnecessary, because for
++	 * our purposes LONG_MIN and LONG_MAX are too large anyway
++	 */
++	if(number == LONG_MIN || number == LONG_MAX)
++		return 0;
++
++	/* reject negative numbers as invalid */
++	if(number < 0)
++		return 0;
++
++	/* check if long result will overflow signed int */
++	if(number > INT_MAX)
++		return 0;
++
++	*res = number;
++	return 1;
++}
++
++
++#define VERSION() \
++	printf("unsquashfs version 4.3 (2014/05/12)\n");\
++	printf("copyright (C) 2014 Phillip Lougher "\
++		"<phillip@squashfs.org.uk>\n\n");\
++    	printf("This program is free software; you can redistribute it and/or"\
++		"\n");\
++	printf("modify it under the terms of the GNU General Public License"\
++		"\n");\
++	printf("as published by the Free Software Foundation; either version "\
++		"2,\n");\
++	printf("or (at your option) any later version.\n\n");\
++	printf("This program is distributed in the hope that it will be "\
++		"useful,\n");\
++	printf("but WITHOUT ANY WARRANTY; without even the implied warranty of"\
++		"\n");\
++	printf("MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the"\
++		"\n");\
++	printf("GNU General Public License for more details.\n");
++int main(int argc, char *argv[])
++{
++	char *dest = "squashfs-root";
++	int i, stat_sys = FALSE, version = FALSE;
++	int n;
++	struct pathnames *paths = NULL;
++	struct pathname *path = NULL;
++	long long directory_table_end;
++	int fragment_buffer_size = FRAGMENT_BUFFER_DEFAULT;
++	int data_buffer_size = DATA_BUFFER_DEFAULT;
++
++	pthread_mutex_init(&screen_mutex, NULL);
++	root_process = geteuid() == 0;
++	if(root_process)
++		umask(0);
++	
++	for(i = 1; i < argc; i++) {
++		if(*argv[i] != '-')
++			break;
++		if(strcmp(argv[i], "-version") == 0 ||
++				strcmp(argv[i], "-v") == 0) {
++			VERSION();
++			version = TRUE;
++		} else if(strcmp(argv[i], "-info") == 0 ||
++				strcmp(argv[i], "-i") == 0)
++			info = TRUE;
++		else if(strcmp(argv[i], "-ls") == 0 ||
++				strcmp(argv[i], "-l") == 0)
++			lsonly = TRUE;
++		else if(strcmp(argv[i], "-no-progress") == 0 ||
++				strcmp(argv[i], "-n") == 0)
++			progress = FALSE;
++		else if(strcmp(argv[i], "-no-xattrs") == 0 ||
++				strcmp(argv[i], "-no") == 0)
++			no_xattrs = TRUE;
++		else if(strcmp(argv[i], "-xattrs") == 0 ||
++				strcmp(argv[i], "-x") == 0)
++			no_xattrs = FALSE;
++		else if(strcmp(argv[i], "-user-xattrs") == 0 ||
++				strcmp(argv[i], "-u") == 0) {
++			user_xattrs = TRUE;
++			no_xattrs = FALSE;
++		} else if(strcmp(argv[i], "-dest") == 0 ||
++				strcmp(argv[i], "-d") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -dest missing filename\n",
++					argv[0]);
++				exit(1);
++			}
++			dest = argv[i];
++		} else if(strcmp(argv[i], "-processors") == 0 ||
++				strcmp(argv[i], "-p") == 0) {
++			if((++i == argc) || 
++					!parse_number(argv[i],
++						&processors)) {
++				ERROR("%s: -processors missing or invalid "
++					"processor number\n", argv[0]);
++				exit(1);
++			}
++			if(processors < 1) {
++				ERROR("%s: -processors should be 1 or larger\n",
++					argv[0]);
++				exit(1);
++			}
++		} else if(strcmp(argv[i], "-data-queue") == 0 ||
++					 strcmp(argv[i], "-da") == 0) {
++			if((++i == argc) ||
++					!parse_number(argv[i],
++						&data_buffer_size)) {
++				ERROR("%s: -data-queue missing or invalid "
++					"queue size\n", argv[0]);
++				exit(1);
++			}
++			if(data_buffer_size < 1) {
++				ERROR("%s: -data-queue should be 1 Mbyte or "
++					"larger\n", argv[0]);
++				exit(1);
++			}
++		} else if(strcmp(argv[i], "-frag-queue") == 0 ||
++					strcmp(argv[i], "-fr") == 0) {
++			if((++i == argc) ||
++					!parse_number(argv[i],
++						&fragment_buffer_size)) {
++				ERROR("%s: -frag-queue missing or invalid "
++					"queue size\n", argv[0]);
++				exit(1);
++			}
++			if(fragment_buffer_size < 1) {
++				ERROR("%s: -frag-queue should be 1 Mbyte or "
++					"larger\n", argv[0]);
++				exit(1);
++			}
++		} else if(strcmp(argv[i], "-force") == 0 ||
++				strcmp(argv[i], "-f") == 0)
++			force = TRUE;
++		else if(strcmp(argv[i], "-stat") == 0 ||
++				strcmp(argv[i], "-s") == 0)
++			stat_sys = TRUE;
++		else if(strcmp(argv[i], "-lls") == 0 ||
++				strcmp(argv[i], "-ll") == 0) {
++			lsonly = TRUE;
++			short_ls = FALSE;
++		} else if(strcmp(argv[i], "-linfo") == 0 ||
++				strcmp(argv[i], "-li") == 0) {
++			info = TRUE;
++			short_ls = FALSE;
++		} else if(strcmp(argv[i], "-ef") == 0 ||
++				strcmp(argv[i], "-e") == 0) {
++			if(++i == argc) {
++				fprintf(stderr, "%s: -ef missing filename\n",
++					argv[0]);
++				exit(1);
++			}
++			path = process_extract_files(path, argv[i]);
++		} else if(strcmp(argv[i], "-regex") == 0 ||
++				strcmp(argv[i], "-r") == 0)
++			use_regex = TRUE;
++		else
++			goto options;
++	}
++
++	if(lsonly || info)
++		progress = FALSE;
++
++#ifdef SQUASHFS_TRACE
++	/*
++	 * Disable progress bar if full debug tracing is enabled.
++	 * The progress bar in this case just gets in the way of the
++	 * debug trace output
++	 */
++	progress = FALSE;
++#endif
++
++	if(i == argc) {
++		if(!version) {
++options:
++			ERROR("SYNTAX: %s [options] filesystem [directories or "
++				"files to extract]\n", argv[0]);
++			ERROR("\t-v[ersion]\t\tprint version, licence and "
++				"copyright information\n");
++			ERROR("\t-d[est] <pathname>\tunsquash to <pathname>, "
++				"default \"squashfs-root\"\n");
++			ERROR("\t-n[o-progress]\t\tdon't display the progress "
++				"bar\n");
++			ERROR("\t-no[-xattrs]\t\tdon't extract xattrs in file system"
++				NOXOPT_STR"\n");
++			ERROR("\t-x[attrs]\t\textract xattrs in file system"
++				XOPT_STR "\n");
++			ERROR("\t-u[ser-xattrs]\t\tonly extract user xattrs in "
++				"file system.\n\t\t\t\tEnables extracting "
++				"xattrs\n");
++			ERROR("\t-p[rocessors] <number>\tuse <number> "
++				"processors.  By default will use\n");
++			ERROR("\t\t\t\tnumber of processors available\n");
++			ERROR("\t-i[nfo]\t\t\tprint files as they are "
++				"unsquashed\n");
++			ERROR("\t-li[nfo]\t\tprint files as they are "
++				"unsquashed with file\n");
++			ERROR("\t\t\t\tattributes (like ls -l output)\n");
++			ERROR("\t-l[s]\t\t\tlist filesystem, but don't unsquash"
++				"\n");
++			ERROR("\t-ll[s]\t\t\tlist filesystem with file "
++				"attributes (like\n");
++			ERROR("\t\t\t\tls -l output), but don't unsquash\n");
++			ERROR("\t-f[orce]\t\tif file already exists then "
++				"overwrite\n");
++			ERROR("\t-s[tat]\t\t\tdisplay filesystem superblock "
++				"information\n");
++			ERROR("\t-e[f] <extract file>\tlist of directories or "
++				"files to extract.\n\t\t\t\tOne per line\n");
++			ERROR("\t-da[ta-queue] <size>\tSet data queue to "
++				"<size> Mbytes.  Default %d\n\t\t\t\tMbytes\n",
++				DATA_BUFFER_DEFAULT);
++			ERROR("\t-fr[ag-queue] <size>\tSet fragment queue to "
++				"<size> Mbytes.  Default\n\t\t\t\t%d Mbytes\n",
++				FRAGMENT_BUFFER_DEFAULT);
++			ERROR("\t-r[egex]\t\ttreat extract names as POSIX "
++				"regular expressions\n");
++			ERROR("\t\t\t\trather than use the default shell "
++				"wildcard\n\t\t\t\texpansion (globbing)\n");
++			ERROR("\nDecompressors available:\n");
++			display_compressors("", "");
++		}
++		exit(1);
++	}
++
++	for(n = i + 1; n < argc; n++)
++		path = add_path(path, argv[n], argv[n]);
++
++	if((fd = open(argv[i], O_RDONLY)) == -1) {
++		ERROR("Could not open %s, because %s\n", argv[i],
++			strerror(errno));
++		exit(1);
++	}
++
++	if(read_super(argv[i]) == FALSE)
++		exit(1);
++
++	if(stat_sys) {
++		squashfs_stat(argv[i]);
++		exit(0);
++	}
++
++	if(!check_compression(comp))
++		exit(1);
++
++	block_size = sBlk.s.block_size;
++	block_log = sBlk.s.block_log;
++
++	/*
++	 * Sanity check block size and block log.
++	 *
++	 * Check they're within correct limits
++	 */
++	if(block_size > SQUASHFS_FILE_MAX_SIZE ||
++					block_log > SQUASHFS_FILE_MAX_LOG)
++		EXIT_UNSQUASH("Block size or block_log too large."
++			"  File system is corrupt.\n");
++
++	/*
++	 * Check block_size and block_log match
++	 */
++	if(block_size != (1 << block_log))
++		EXIT_UNSQUASH("Block size and block_log do not match."
++			"  File system is corrupt.\n");
++
++	/*
++	 * convert from queue size in Mbytes to queue size in
++	 * blocks.
++	 *
++	 * In doing so, check that the user supplied values do not
++	 * overflow a signed int
++	 */
++	if(shift_overflow(fragment_buffer_size, 20 - block_log))
++		EXIT_UNSQUASH("Fragment queue size is too large\n");
++	else
++		fragment_buffer_size <<= 20 - block_log;
++
++	if(shift_overflow(data_buffer_size, 20 - block_log))
++		EXIT_UNSQUASH("Data queue size is too large\n");
++	else
++		data_buffer_size <<= 20 - block_log;
++
++	initialise_threads(fragment_buffer_size, data_buffer_size);
++
++	fragment_data = malloc(block_size);
++	if(fragment_data == NULL)
++		EXIT_UNSQUASH("failed to allocate fragment_data\n");
++
++	file_data = malloc(block_size);
++	if(file_data == NULL)
++		EXIT_UNSQUASH("failed to allocate file_data");
++
++	data = malloc(block_size);
++	if(data == NULL)
++		EXIT_UNSQUASH("failed to allocate data\n");
++
++	created_inode = malloc(sBlk.s.inodes * sizeof(char *));
++	if(created_inode == NULL)
++		EXIT_UNSQUASH("failed to allocate created_inode\n");
++
++	memset(created_inode, 0, sBlk.s.inodes * sizeof(char *));
++
++	if(s_ops.read_uids_guids() == FALSE)
++		EXIT_UNSQUASH("failed to uid/gid table\n");
++
++	if(s_ops.read_fragment_table(&directory_table_end) == FALSE)
++		EXIT_UNSQUASH("failed to read fragment table\n");
++
++	if(read_inode_table(sBlk.s.inode_table_start,
++				sBlk.s.directory_table_start) == FALSE)
++		EXIT_UNSQUASH("failed to read inode table\n");
++
++	if(read_directory_table(sBlk.s.directory_table_start,
++				directory_table_end) == FALSE)
++		EXIT_UNSQUASH("failed to read directory table\n");
++
++	if(no_xattrs)
++		sBlk.s.xattr_id_table_start = SQUASHFS_INVALID_BLK;
++
++	if(read_xattrs_from_disk(fd, &sBlk.s) == 0)
++		EXIT_UNSQUASH("failed to read the xattr table\n");
++
++	if(path) {
++		paths = init_subdir();
++		paths = add_subdir(paths, path);
++	}
++
++	pre_scan(dest, SQUASHFS_INODE_BLK(sBlk.s.root_inode),
++		SQUASHFS_INODE_OFFSET(sBlk.s.root_inode), paths);
++
++	memset(created_inode, 0, sBlk.s.inodes * sizeof(char *));
++	inode_number = 1;
++
++	printf("%d inodes (%d blocks) to write\n\n", total_inodes,
++		total_inodes - total_files + total_blocks);
++
++	enable_progress_bar();
++
++	dir_scan(dest, SQUASHFS_INODE_BLK(sBlk.s.root_inode),
++		SQUASHFS_INODE_OFFSET(sBlk.s.root_inode), paths);
++
++	queue_put(to_writer, NULL);
++	queue_get(from_writer);
++
++	disable_progress_bar();
++
++	if(!lsonly) {
++		printf("\n");
++		printf("created %d files\n", file_count);
++		printf("created %d directories\n", dir_count);
++		printf("created %d symlinks\n", sym_count);
++		printf("created %d devices\n", dev_count);
++		printf("created %d fifos\n", fifo_count);
++	}
++
++	return 0;
++}

--- a/patches/patch0.txt
+++ b/patches/patch0.txt
@@ -1,6 +1,6 @@
 diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patched/compressor.c
 --- squashfs-tools/compressor.c	2014-03-09 06:31:58.000000000 +0100
-+++ squashfs-tools-patched/compressor.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/compressor.c	2024-12-27 00:07:21.377156646 +0100
 @@ -25,6 +25,9 @@
  #include "compressor.h"
  #include "squashfs_fs.h"
@@ -122,7 +122,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.c squashfs-tools-patc
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patched/compressor.h
 --- squashfs-tools/compressor.h	2014-05-10 06:54:13.000000000 +0200
-+++ squashfs-tools-patched/compressor.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/compressor.h	2024-12-27 00:07:21.378156659 +0100
 @@ -59,11 +59,14 @@
  }
  
@@ -140,7 +140,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/compressor.h squashfs-tools-patc
  /*
 diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/error.h
 --- squashfs-tools/error.h	2014-05-10 06:54:13.000000000 +0200
-+++ squashfs-tools-patched/error.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/error.h	2024-12-27 00:07:21.378156659 +0100
 @@ -30,14 +30,18 @@
  extern void progressbar_error(char *fmt, ...);
  extern void progressbar_info(char *fmt, ...);
@@ -164,7 +164,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/error.h squashfs-tools-patched/e
  		do {\
 diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/LICENSE
 --- squashfs-tools/LICENSE	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LICENSE	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LICENSE	2024-12-27 00:07:21.379156672 +0100
 @@ -0,0 +1,339 @@
 +                    GNU GENERAL PUBLIC LICENSE
 +                       Version 2, June 1991
@@ -507,7 +507,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LICENSE squashfs-tools-patched/L
 +Public License instead of this License.
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-tools-patched/LZMA/lzma465/7zC.txt
 --- squashfs-tools/LZMA/lzma465/7zC.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/7zC.txt	2024-12-27 00:07:21.379156672 +0100
 @@ -0,0 +1,194 @@
 +7z ANSI-C Decoder 4.62
 +----------------------
@@ -705,7 +705,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zC.txt squashfs-to
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squashfs-tools-patched/LZMA/lzma465/7zFormat.txt
 --- squashfs-tools/LZMA/lzma465/7zFormat.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/7zFormat.txt	2024-12-27 00:07:21.380156686 +0100
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -1180,7 +1180,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/7zFormat.txt squash
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c
 --- squashfs-tools/LZMA/lzma465/C/7zBuf2.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf2.c	2024-12-27 00:07:21.380156686 +0100
 @@ -0,0 +1,45 @@
 +/* 7zBuf2.c -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1229,7 +1229,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf2.c squashfs
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c
 --- squashfs-tools/LZMA/lzma465/C/7zBuf.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.c	2024-12-27 00:07:21.380156686 +0100
 @@ -0,0 +1,36 @@
 +/* 7zBuf.c -- Byte Buffer
 +2008-03-28
@@ -1269,7 +1269,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.c squashfs-
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h
 --- squashfs-tools/LZMA/lzma465/C/7zBuf.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zBuf.h	2024-12-27 00:07:21.380156686 +0100
 @@ -0,0 +1,31 @@
 +/* 7zBuf.h -- Byte Buffer
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -1304,7 +1304,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zBuf.h squashfs-
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c
 --- squashfs-tools/LZMA/lzma465/C/7zCrc.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.c	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,35 @@
 +/* 7zCrc.c -- CRC32 calculation
 +2008-08-05
@@ -1343,7 +1343,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.c squashfs-
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h
 --- squashfs-tools/LZMA/lzma465/C/7zCrc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zCrc.h	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h -- CRC32 calculation
 +2008-03-13
@@ -1371,7 +1371,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zCrc.h squashfs-
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs-tools-patched/LZMA/lzma465/C/7zFile.c
 --- squashfs-tools/LZMA/lzma465/C/7zFile.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.c	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,263 @@
 +/* 7zFile.c -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1638,7 +1638,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.c squashfs
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs-tools-patched/LZMA/lzma465/C/7zFile.h
 --- squashfs-tools/LZMA/lzma465/C/7zFile.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zFile.h	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,74 @@
 +/* 7zFile.h -- File IO
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -1716,7 +1716,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zFile.h squashfs
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squashfs-tools-patched/LZMA/lzma465/C/7zStream.c
 --- squashfs-tools/LZMA/lzma465/C/7zStream.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zStream.c	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,169 @@
 +/* 7zStream.c -- 7z Stream functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -1889,7 +1889,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zStream.c squash
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h
 --- squashfs-tools/LZMA/lzma465/C/7zVersion.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/7zVersion.h	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,7 @@
 +#define MY_VER_MAJOR 4
 +#define MY_VER_MINOR 65
@@ -1900,7 +1900,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/7zVersion.h squas
 +#define MY_VERSION_COPYRIGHT_DATE MY_VERSION " " MY_COPYRIGHT " : " MY_DATE
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-tools-patched/LZMA/lzma465/C/Alloc.c
 --- squashfs-tools/LZMA/lzma465/C/Alloc.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.c	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,127 @@
 +/* Alloc.c -- Memory allocation functions
 +2008-09-24
@@ -2031,7 +2031,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.c squashfs-
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-tools-patched/LZMA/lzma465/C/Alloc.h
 --- squashfs-tools/LZMA/lzma465/C/Alloc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Alloc.h	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,32 @@
 +/* Alloc.h -- Memory allocation functions
 +2008-03-13
@@ -2067,7 +2067,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Alloc.h squashfs-
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.c	2024-12-27 00:07:21.381156699 +0100
 @@ -0,0 +1,77 @@
 +/* 7zAlloc.c -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2148,7 +2148,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAlloc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zAlloc.h	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,15 @@
 +/* 7zAlloc.h -- Allocation functions
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2167,7 +2167,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zAllo
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.c	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,254 @@
 +/* 7zDecode.c -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2425,7 +2425,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDecode.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zDecode.h	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,13 @@
 +/* 7zDecode.h -- Decoding from 7z folder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2442,7 +2442,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zDeco
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsp	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,199 @@
 +# Microsoft Developer Studio Project File - Name="7z" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -2645,7 +2645,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsp
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7z.dsw	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -2678,7 +2678,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7z.dsw
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.c	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,93 @@
 +/* 7zExtract.c -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2775,7 +2775,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtract.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zExtract.h	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,41 @@
 +/* 7zExtract.h -- Extracting from 7z archive
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -2820,7 +2820,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zExtr
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.c	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,6 @@
 +/*  7zHeader.c -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2830,7 +2830,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHeader.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zHeader.h	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,57 @@
 +/* 7zHeader.h -- 7z Headers
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -2891,7 +2891,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zHead
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.c	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,1204 @@
 +/* 7zIn.c -- 7z Input functions
 +2008-12-31 : Igor Pavlov : Public domain */
@@ -4099,7 +4099,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.c
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zIn.h	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,41 @@
 +/* 7zIn.h -- 7z Input functions
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4144,7 +4144,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zIn.h
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.c	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,127 @@
 +/* 7zItem.c -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4275,7 +4275,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zItem.h	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,84 @@
 +/* 7zItem.h -- 7z Items
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4363,7 +4363,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zItem
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/7zMain.c	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,262 @@
 +/* 7zMain.c - Test application for 7z Decoder
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -4629,7 +4629,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/7zMain
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,33 @@
 +MY_STATIC_LINK=1
 +
@@ -4666,7 +4666,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc
 --- squashfs-tools/LZMA/lzma465/C/Archive/7z/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Archive/7z/makefile.gcc	2024-12-27 00:07:21.382156713 +0100
 @@ -0,0 +1,61 @@
 +PROG = 7zDec
 +CXX = g++
@@ -4731,7 +4731,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Archive/7z/makefi
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c
 --- squashfs-tools/LZMA/lzma465/C/Bcj2.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.c	2024-12-27 00:07:21.383156726 +0100
 @@ -0,0 +1,132 @@
 +/* Bcj2.c -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4867,7 +4867,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.c squashfs-t
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h
 --- squashfs-tools/LZMA/lzma465/C/Bcj2.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bcj2.h	2024-12-27 00:07:21.383156726 +0100
 @@ -0,0 +1,30 @@
 +/* Bcj2.h -- Converter for x86 code (BCJ2)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4901,7 +4901,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bcj2.h squashfs-t
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-tools-patched/LZMA/lzma465/C/Bra86.c
 --- squashfs-tools/LZMA/lzma465/C/Bra86.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra86.c	2024-12-27 00:07:21.383156726 +0100
 @@ -0,0 +1,85 @@
 +/* Bra86.c -- Converter for x86 code (BCJ)
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -4990,7 +4990,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra86.c squashfs-
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-tools-patched/LZMA/lzma465/C/Bra.c
 --- squashfs-tools/LZMA/lzma465/C/Bra.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.c	2024-12-27 00:07:21.383156726 +0100
 @@ -0,0 +1,133 @@
 +/* Bra.c -- Converters for RISC code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5127,7 +5127,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.c squashfs-to
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-tools-patched/LZMA/lzma465/C/Bra.h
 --- squashfs-tools/LZMA/lzma465/C/Bra.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Bra.h	2024-12-27 00:07:21.383156726 +0100
 @@ -0,0 +1,60 @@
 +/* Bra.h -- Branch converters for executables
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5191,7 +5191,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Bra.h squashfs-to
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c
 --- squashfs-tools/LZMA/lzma465/C/BraIA64.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/BraIA64.c	2024-12-27 00:07:21.383156726 +0100
 @@ -0,0 +1,67 @@
 +/* BraIA64.c -- Converter for IA-64 code
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -5262,7 +5262,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/BraIA64.c squashf
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h
 --- squashfs-tools/LZMA/lzma465/C/CpuArch.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/CpuArch.h	2024-12-27 00:07:21.383156726 +0100
 @@ -0,0 +1,69 @@
 +/* CpuArch.h
 +2008-08-05
@@ -5335,7 +5335,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/CpuArch.h squashf
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs-tools-patched/LZMA/lzma465/C/LzFind.c
 --- squashfs-tools/LZMA/lzma465/C/LzFind.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.c	2024-12-27 00:07:21.384156739 +0100
 @@ -0,0 +1,751 @@
 +/* LzFind.c -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6090,7 +6090,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.c squashfs
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs-tools-patched/LZMA/lzma465/C/LzFind.h
 --- squashfs-tools/LZMA/lzma465/C/LzFind.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFind.h	2024-12-27 00:07:21.385156753 +0100
 @@ -0,0 +1,107 @@
 +/* LzFind.h -- Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6201,7 +6201,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFind.h squashfs
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c
 --- squashfs-tools/LZMA/lzma465/C/LzFindMt.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.c	2024-12-27 00:07:21.385156753 +0100
 @@ -0,0 +1,793 @@
 +/* LzFindMt.c -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -6998,7 +6998,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.c squash
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h
 --- squashfs-tools/LZMA/lzma465/C/LzFindMt.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzFindMt.h	2024-12-27 00:07:21.386156766 +0100
 @@ -0,0 +1,97 @@
 +/* LzFindMt.h -- multithreaded Match finder for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7099,7 +7099,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzFindMt.h squash
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs-tools-patched/LZMA/lzma465/C/LzHash.h
 --- squashfs-tools/LZMA/lzma465/C/LzHash.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzHash.h	2024-12-27 00:07:21.386156766 +0100
 @@ -0,0 +1,54 @@
 +/* LzHash.h -- HASH functions for LZ algorithms
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -7157,7 +7157,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzHash.h squashfs
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c
 --- squashfs-tools/LZMA/lzma465/C/LzmaDec.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.c	2024-12-27 00:07:21.386156766 +0100
 @@ -0,0 +1,1007 @@
 +/* LzmaDec.c -- LZMA Decoder
 +2008-11-06 : Igor Pavlov : Public domain */
@@ -8168,7 +8168,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.c squashf
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h
 --- squashfs-tools/LZMA/lzma465/C/LzmaDec.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaDec.h	2024-12-27 00:07:21.387156779 +0100
 @@ -0,0 +1,223 @@
 +/* LzmaDec.h -- LZMA Decoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -8395,7 +8395,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaDec.h squashf
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c
 --- squashfs-tools/LZMA/lzma465/C/LzmaEnc.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.c	2024-12-27 00:07:21.388156793 +0100
 @@ -0,0 +1,2281 @@
 +/* LzmaEnc.c -- LZMA Encoder
 +2009-02-02 : Igor Pavlov : Public domain */
@@ -10680,7 +10680,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.c squashf
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h
 --- squashfs-tools/LZMA/lzma465/C/LzmaEnc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaEnc.h	2024-12-27 00:07:21.388156793 +0100
 @@ -0,0 +1,72 @@
 +/*  LzmaEnc.h -- LZMA Encoder
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10756,7 +10756,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaEnc.h squashf
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.def	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.def	2024-12-27 00:07:21.388156793 +0100
 @@ -0,0 +1,4 @@
 +EXPORTS
 +  LzmaCompress
@@ -10764,7 +10764,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsp	2024-12-27 00:07:21.388156793 +0100
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="LzmaLib" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -10946,7 +10946,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLib.dsw	2024-12-27 00:07:21.388156793 +0100
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -10979,7 +10979,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLib.d
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/LzmaLibExports.c	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,12 @@
 +/* LzmaLibExports.c -- LZMA library DLL Entry point
 +2008-10-04 : Igor Pavlov : Public domain */
@@ -10995,7 +10995,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/LzmaLibEx
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/makefile	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,37 @@
 +MY_STATIC_LINK=1
 +SLIB = sLZMA.lib
@@ -11036,7 +11036,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/makefile 
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.rc	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib/resource.rc	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,4 @@
 +#include "../../CPP/7zip/MyVersionInfo.rc"
 +
@@ -11044,7 +11044,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib/resource.
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.c	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,46 @@
 +/* LzmaLib.c -- LZMA library wrapper
 +2008-08-05
@@ -11094,7 +11094,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.c squashf
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h
 --- squashfs-tools/LZMA/lzma465/C/LzmaLib.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaLib.h	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,135 @@
 +/* LzmaLib.h -- LZMA library interface
 +2008-08-05
@@ -11233,7 +11233,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaLib.h squashf
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.c	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,61 @@
 +/* Lzma86Dec.c -- LZMA + x86 (BCJ) Filter Decoder
 +2008-04-07
@@ -11298,7 +11298,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Dec.h	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,45 @@
 +/* Lzma86Dec.h -- LZMA + x86 (BCJ) Filter Decoder
 +2008-08-05
@@ -11347,7 +11347,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86De
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.c	2024-12-27 00:07:21.389156806 +0100
 @@ -0,0 +1,113 @@
 +/* Lzma86Enc.c -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11464,7 +11464,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/Lzma86Enc.h	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,72 @@
 +/* Lzma86Enc.h -- LZMA + x86 (BCJ) Filter Encoder
 +2008-08-05
@@ -11540,7 +11540,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/Lzma86En
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.c	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,254 @@
 +/* LzmaUtil.c -- Test application for LZMA compression
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -11798,7 +11798,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsp	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,168 @@
 +# Microsoft Developer Studio Project File - Name="LzmaUtil" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -11970,7 +11970,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/LzmaUtil.dsw	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -12003,7 +12003,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/LzmaUtil
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,29 @@
 +MY_STATIC_LINK=1
 +PROG = LZMAc.exe
@@ -12036,7 +12036,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc
 --- squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/LzmaUtil/makefile.gcc	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,44 @@
 +PROG = lzma
 +CXX = g++
@@ -12084,7 +12084,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/LzmaUtil/makefile
 +	-$(RM) $(PROG) $(OBJS)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashfs-tools-patched/LZMA/lzma465/C/Threads.c
 --- squashfs-tools/LZMA/lzma465/C/Threads.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.c	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,109 @@
 +/* Threads.c -- multithreading library
 +2008-08-05
@@ -12197,7 +12197,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.c squashf
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashfs-tools-patched/LZMA/lzma465/C/Threads.h
 --- squashfs-tools/LZMA/lzma465/C/Threads.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Threads.h	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,68 @@
 +/* Threads.h -- multithreading library
 +2008-11-22 : Igor Pavlov : Public domain */
@@ -12269,7 +12269,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Threads.h squashf
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-tools-patched/LZMA/lzma465/C/Types.h
 --- squashfs-tools/LZMA/lzma465/C/Types.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/C/Types.h	2024-12-27 00:07:21.390156819 +0100
 @@ -0,0 +1,208 @@
 +/* Types.h -- Basic types
 +2008-11-23 : Igor Pavlov : Public domain */
@@ -12481,7 +12481,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/C/Types.h squashfs-
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashfs-tools-patched/LZMA/lzma465/history.txt
 --- squashfs-tools/LZMA/lzma465/history.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/history.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/history.txt	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,236 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -12721,7 +12721,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/history.txt squashf
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-tools-patched/LZMA/lzma465/lzma.txt
 --- squashfs-tools/LZMA/lzma465/lzma.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/lzma.txt	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,594 @@
 +LZMA SDK 4.65
 +-------------
@@ -13319,7 +13319,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/lzma.txt squashfs-t
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashfs-tools-patched/LZMA/lzma465/Methods.txt
 --- squashfs-tools/LZMA/lzma465/Methods.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzma465/Methods.txt	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,137 @@
 +7-Zip method IDs (4.65)
 +-----------------------
@@ -13460,7 +13460,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzma465/Methods.txt squashf
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt
 --- squashfs-tools/LZMA/lzmadaptive/7zC.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zC.txt	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,235 @@
 +7z ANSI-C Decoder 4.23
 +----------------------
@@ -13699,7 +13699,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zC.txt squashf
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt
 --- squashfs-tools/LZMA/lzmadaptive/7zFormat.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/7zFormat.txt	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,471 @@
 +7z Format description (2.30 Beta 25)
 +-----------------------------------
@@ -14174,7 +14174,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/7zFormat.txt sq
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.c	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,70 @@
 +/* 7zAlloc.c */
 +
@@ -14248,7 +14248,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zAlloc.h	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,20 @@
 +/* 7zAlloc.h */
 +
@@ -14272,7 +14272,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.c	2024-12-27 00:07:21.391156833 +0100
 @@ -0,0 +1,29 @@
 +/* 7zBuffer.c */
 +
@@ -14305,7 +14305,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zBuffer.h	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,19 @@
 +/* 7zBuffer.h */
 +
@@ -14328,7 +14328,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsp	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,178 @@
 +# Microsoft Developer Studio Project File - Name="7z_C" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -14510,7 +14510,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7z_C.dsw	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -14543,7 +14543,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.c	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,76 @@
 +/* 7zCrc.c */
 +
@@ -14623,7 +14623,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zCrc.h	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,24 @@
 +/* 7zCrc.h */
 +
@@ -14651,7 +14651,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.c	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,150 @@
 +/* 7zDecode.c */
 +
@@ -14805,7 +14805,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zDecode.h	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,21 @@
 +/* 7zDecode.h */
 +
@@ -14830,7 +14830,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.c	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,116 @@
 +/* 7zExtract.c */
 +
@@ -14950,7 +14950,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zExtract.h	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,40 @@
 +/* 7zExtract.h */
 +
@@ -14994,7 +14994,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.c	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,5 @@
 +/*  7zHeader.c */
 +
@@ -15003,7 +15003,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +Byte k7zSignature[k7zSignatureSize] = {'7', 'z', 0xBC, 0xAF, 0x27, 0x1C};
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zHeader.h	2024-12-27 00:07:21.392156846 +0100
 @@ -0,0 +1,55 @@
 +/* 7zHeader.h */
 +
@@ -15062,7 +15062,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.c	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,1292 @@
 +/* 7zIn.c */
 +
@@ -16358,7 +16358,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zIn.h	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,55 @@
 +/* 7zIn.h */
 +
@@ -16417,7 +16417,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.c	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,133 @@
 +/* 7zItem.c */
 +
@@ -16554,7 +16554,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zItem.h	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,90 @@
 +/* 7zItem.h */
 +
@@ -16648,7 +16648,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMain.c	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,223 @@
 +/* 
 +7zMain.c
@@ -16875,7 +16875,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.c	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,14 @@
 +/* 7zMethodID.c */
 +
@@ -16893,7 +16893,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zMethodID.h	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,18 @@
 +/* 7zMethodID.h */
 +
@@ -16915,7 +16915,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/7zTypes.h	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,61 @@
 +/* 7zTypes.h */
 +
@@ -16980,7 +16980,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,55 @@
 +PROG = 7zDec.exe
 +
@@ -17039,7 +17039,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Archive/7z_C/makefile.gcc	2024-12-27 00:07:21.393156859 +0100
 @@ -0,0 +1,50 @@
 +PROG = 7zDec
 +CXX = g++
@@ -17093,7 +17093,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Archive/
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.cpp	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,251 @@
 +// FileStreams.cpp
 +
@@ -17348,7 +17348,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/FileStreams.h	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,98 @@
 +// FileStreams.h
 +
@@ -17450,7 +17450,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/F
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.cpp	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,80 @@
 +// InBuffer.cpp
 +
@@ -17534,7 +17534,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/InBuffer.h	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,76 @@
 +// InBuffer.h
 +
@@ -17614,7 +17614,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/I
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.cpp	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,117 @@
 +// OutByte.cpp
 +
@@ -17735,7 +17735,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/OutBuffer.h	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,64 @@
 +// OutBuffer.h
 +
@@ -17803,7 +17803,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/O
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StdAfx.h	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -17816,7 +17816,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.cpp	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,44 @@
 +// StreamUtils.cpp
 +
@@ -17864,7 +17864,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Common/StreamUtils.h	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,11 @@
 +// StreamUtils.h
 +
@@ -17879,7 +17879,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Common/S
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.cpp	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,16 @@
 +// ARM.cpp
 +
@@ -17899,7 +17899,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARM.h	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,10 @@
 +// ARM.h
 +
@@ -17913,7 +17913,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.cpp	2024-12-27 00:07:21.394156873 +0100
 @@ -0,0 +1,16 @@
 +// ARMThumb.cpp
 +
@@ -17933,7 +17933,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/ARMThumb.h	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,10 @@
 +// ARMThumb.h
 +
@@ -17947,7 +17947,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.c	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,26 @@
 +// BranchARM.c
 +
@@ -17977,7 +17977,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARM.h	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,10 @@
 +// BranchARM.h
 +
@@ -17991,7 +17991,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.c	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,35 @@
 +// BranchARMThumb.c
 +
@@ -18030,7 +18030,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchARMThumb.h	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,10 @@
 +// BranchARMThumb.h
 +
@@ -18044,7 +18044,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.cpp	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,18 @@
 +// BranchCoder.cpp
 +
@@ -18066,7 +18066,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchCoder.h	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,54 @@
 +// BranchCoder.h
 +
@@ -18124,7 +18124,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.c	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,65 @@
 +// BranchIA64.c
 +
@@ -18193,7 +18193,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchIA64.h	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,10 @@
 +// BranchIA64.h
 +
@@ -18207,7 +18207,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.c	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,36 @@
 +// BranchPPC.c
 +
@@ -18247,7 +18247,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchPPC.h	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,10 @@
 +// BranchPPC.h
 +
@@ -18261,7 +18261,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.c	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,36 @@
 +// BranchSPARC.c
 +
@@ -18301,7 +18301,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchSPARC.h	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,10 @@
 +// BranchSPARC.h
 +
@@ -18315,7 +18315,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.c	2024-12-27 00:07:21.395156886 +0100
 @@ -0,0 +1,101 @@
 +/* BranchX86.c */
 +
@@ -18420,7 +18420,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/BranchX86.h	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,19 @@
 +/* BranchX86.h */
 +
@@ -18443,7 +18443,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.cpp	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,16 @@
 +// IA64.cpp
 +
@@ -18463,7 +18463,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/IA64.h	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,10 @@
 +// IA64.h
 +
@@ -18477,7 +18477,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.cpp	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,17 @@
 +// PPC.cpp
 +
@@ -18498,7 +18498,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/PPC.h	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,10 @@
 +// PPC.h
 +
@@ -18512,7 +18512,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.cpp	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,17 @@
 +// SPARC.cpp
 +
@@ -18533,7 +18533,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/SPARC.h	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,10 @@
 +// SPARC.h
 +
@@ -18547,7 +18547,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/StdAfx.h	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -18559,7 +18559,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.cpp	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,412 @@
 +// x86_2.cpp
 +
@@ -18975,7 +18975,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86_2.h	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,133 @@
 +// x86_2.h
 +
@@ -19112,7 +19112,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.cpp	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,18 @@
 +// x86.cpp
 +
@@ -19134,7 +19134,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/Branch/x86.h	2024-12-27 00:07:21.396156899 +0100
 @@ -0,0 +1,19 @@
 +// x86.h
 +
@@ -19157,7 +19157,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree2.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,12 @@
 +// BinTree2.h
 +
@@ -19173,7 +19173,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,16 @@
 +// BinTree3.h
 +
@@ -19193,7 +19193,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree3Z.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,16 @@
 +// BinTree3Z.h
 +
@@ -19213,7 +19213,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4b.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,20 @@
 +// BinTree4b.h
 +
@@ -19237,7 +19237,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree4.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,18 @@
 +// BinTree4.h
 +
@@ -19259,7 +19259,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTree.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,55 @@
 +// BinTree.h
 +
@@ -19318,7 +19318,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/BinTree/BinTreeMain.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,444 @@
 +// BinTreeMain.h
 +
@@ -19766,7 +19766,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC2.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,13 @@
 +// HC2.h
 +
@@ -19783,7 +19783,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC3.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,17 @@
 +// HC3.h
 +
@@ -19804,7 +19804,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4b.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,21 @@
 +// HC4b.h
 +
@@ -19829,7 +19829,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC4.h	2024-12-27 00:07:21.397156913 +0100
 @@ -0,0 +1,19 @@
 +// HC4.h
 +
@@ -19852,7 +19852,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HC.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,55 @@
 +// HC.h
 +
@@ -19911,7 +19911,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/HashChain/HCMain.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,350 @@
 +// HC.h
 +
@@ -20265,7 +20265,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/IMatchFinder.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,63 @@
 +// MatchFinders/IMatchFinder.h
 +
@@ -20332,7 +20332,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.cpp	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,102 @@
 +// LZInWindow.cpp
 +
@@ -20438,7 +20438,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZInWindow.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,84 @@
 +// LZInWindow.h
 +
@@ -20526,7 +20526,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.cpp	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,17 @@
 +// LZOutWindow.cpp
 +
@@ -20547,7 +20547,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/LZOutWindow.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,64 @@
 +// LZOutWindow.h
 +
@@ -20615,7 +20615,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,22 @@
 +// Pat2.h
 +
@@ -20641,7 +20641,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2H.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,24 @@
 +// Pat2H.h
 +
@@ -20669,7 +20669,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat2R.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,20 @@
 +// Pat2R.h
 +
@@ -20693,7 +20693,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat3H.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,24 @@
 +// Pat3H.h
 +
@@ -20721,7 +20721,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat4H.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,24 @@
 +// Pat4H.h
 +
@@ -20749,7 +20749,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/Pat.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,318 @@
 +// Pat.h
 +
@@ -21071,7 +21071,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +// #endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/Patricia/PatMain.h	2024-12-27 00:07:21.398156926 +0100
 @@ -0,0 +1,989 @@
 +// PatMain.h
 +
@@ -22064,7 +22064,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZ/StdAfx.h	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -22074,7 +22074,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.cpp	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,342 @@
 +// LZMADecoder.cpp
 +
@@ -22420,7 +22420,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMADecoder.h	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,249 @@
 +// LZMA/Decoder.h
 +
@@ -22673,7 +22673,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.cpp	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,1504 @@
 +// LZMA/Encoder.cpp
 +
@@ -24181,7 +24181,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMAEncoder.h	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,416 @@
 +// LZMA/Encoder.h
 +
@@ -24601,7 +24601,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/LZMA.h	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,82 @@
 +// LZMA.h
 +
@@ -24687,7 +24687,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA/StdAfx.h	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -24699,7 +24699,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsp	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,523 @@
 +# Microsoft Developer Studio Project File - Name="AloneLZMA" - Package Owner=<4>
 +# Microsoft Developer Studio Generated Build File, Format Version 6.00
@@ -25226,7 +25226,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +# End Project
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/AloneLZMA.dsw	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,29 @@
 +Microsoft Developer Studio Workspace File, Format Version 6.00
 +# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
@@ -25259,7 +25259,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaAlone.cpp	2024-12-27 00:07:21.399156940 +0100
 @@ -0,0 +1,509 @@
 +// LzmaAlone.cpp
 +
@@ -25772,7 +25772,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.cpp	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,508 @@
 +// LzmaBench.cpp
 +
@@ -26284,7 +26284,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaBench.h	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,11 @@
 +// LzmaBench.h
 +
@@ -26299,7 +26299,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.cpp	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,228 @@
 +// LzmaRam.cpp
 +
@@ -26531,7 +26531,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.c	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,79 @@
 +/* LzmaRamDecode.c */
 +
@@ -26614,7 +26614,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRamDecode.h	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,55 @@
 +/* LzmaRamDecode.h */
 +
@@ -26673,7 +26673,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/LzmaRam.h	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,46 @@
 +// LzmaRam.h
 +
@@ -26723,7 +26723,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,100 @@
 +PROG = lzma.exe
 +CFLAGS = $(CFLAGS) -I ../../../
@@ -26827,7 +26827,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/makefile.gcc	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,113 @@
 +PROG = lzma
 +CXX = g++ -O2 -Wall
@@ -26944,14 +26944,14 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.cpp	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,3 @@
 +// StdAfx.cpp
 +
 +#include "StdAfx.h"
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Alone/StdAfx.h	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,8 @@
 +// StdAfx.h
 +
@@ -26963,7 +26963,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.c	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,588 @@
 +/*
 +  LzmaDecode.c
@@ -27555,7 +27555,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecode.h	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,131 @@
 +/* 
 +  LzmaDecode.h
@@ -27690,7 +27690,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaDecodeSize.c	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,716 @@
 +/*
 +  LzmaDecodeSize.c
@@ -28410,7 +28410,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.c	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,521 @@
 +/*
 +  LzmaStateDecode.c
@@ -28935,7 +28935,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateDecode.h	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,115 @@
 +/* 
 +  LzmaStateDecode.h
@@ -29054,7 +29054,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaStateTest.c	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,195 @@
 +/* 
 +LzmaStateTest.c
@@ -29253,7 +29253,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/LzmaTest.c	2024-12-27 00:07:21.400156953 +0100
 @@ -0,0 +1,342 @@
 +/* 
 +LzmaTest.c
@@ -29599,7 +29599,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,43 @@
 +PROG = lzmaDec.exe
 +
@@ -29646,7 +29646,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +	$(COMPL_O2)
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_C/makefile.gcc	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,23 @@
 +PROG = lzmadec
 +CXX = gcc 
@@ -29673,7 +29673,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/lzmadaptive.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,21 @@
 +#ifndef __LZMA_LIB_H__
 +#define __LZMA_LIB_H__
@@ -29698,7 +29698,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/makefile	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,92 @@
 +PROG = liblzmalib.a
 +CXX = g++ -O3 -Wall
@@ -29794,7 +29794,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/LZMA_Lib/ZLib.cpp	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,451 @@
 +/*
 + * lzma zlib simplified wrapper
@@ -30249,7 +30249,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.cpp	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,80 @@
 +// Compress/RangeCoder/RangeCoderBit.cpp
 +
@@ -30333,7 +30333,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBit.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,120 @@
 +// Compress/RangeCoder/RangeCoderBit.h
 +
@@ -30457,7 +30457,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderBitTree.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,161 @@
 +// Compress/RangeCoder/RangeCoderBitTree.h
 +
@@ -30622,7 +30622,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoder.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,205 @@
 +// Compress/RangeCoder/RangeCoder.h
 +
@@ -30831,7 +30831,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/RangeCoderOpt.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,31 @@
 +// Compress/RangeCoder/RangeCoderOpt.h
 +
@@ -30866,7 +30866,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/Compress/RangeCoder/StdAfx.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,6 @@
 +// StdAfx.h
 +
@@ -30876,7 +30876,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/Compress
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/ICoder.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,156 @@
 +// ICoder.h
 +
@@ -31036,7 +31036,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/ICoder.h
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h
 --- squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/7zip/IStream.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,62 @@
 +// IStream.h
 +
@@ -31102,7 +31102,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/7zip/IStream.
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.cpp	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,118 @@
 +// Common/Alloc.cpp
 +
@@ -31224,7 +31224,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Alloc.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,29 @@
 +// Common/Alloc.h
 +
@@ -31257,7 +31257,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Alloc.
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.cpp	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,78 @@
 +// Common/C_FileIO.h
 +
@@ -31339,7 +31339,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +}}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/C_FileIO.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/C_FileIO.h	2024-12-27 00:07:21.401156966 +0100
 @@ -0,0 +1,45 @@
 +// Common/C_FileIO.h
 +
@@ -31388,7 +31388,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/C_File
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.cpp	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,263 @@
 +// CommandLineParser.cpp
 +
@@ -31655,7 +31655,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/CommandLineParser.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CommandLineParser.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,82 @@
 +// Common/CommandLineParser.h
 +
@@ -31741,7 +31741,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Comman
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/ComTry.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,17 @@
 +// ComTry.h
 +
@@ -31762,7 +31762,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/ComTry
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.cpp	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,61 @@
 +// Common/CRC.cpp
 +
@@ -31827,7 +31827,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.cp
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/CRC.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,36 @@
 +// Common/CRC.h
 +
@@ -31867,7 +31867,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/CRC.h 
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Defs.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,20 @@
 +// Common/Defs.h
 +
@@ -31891,7 +31891,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Defs.h
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyCom.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,203 @@
 +// MyCom.h
 +
@@ -32098,7 +32098,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyCom.
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuidDef.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyGuidDef.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,54 @@
 +// Common/MyGuidDef.h
 +
@@ -32156,7 +32156,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyGuid
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/MyInitGuid.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyInitGuid.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,13 @@
 +// Common/MyInitGuid.h
 +
@@ -32173,7 +32173,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyInit
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnknown.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyUnknown.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,24 @@
 +// MyUnknown.h
 +
@@ -32201,7 +32201,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyUnkn
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/MyWindows.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/MyWindows.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,183 @@
 +// MyWindows.h
 +
@@ -32388,7 +32388,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/MyWind
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.cpp	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,114 @@
 +// NewHandler.cpp
 + 
@@ -32506,7 +32506,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +*/
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/NewHandler.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/NewHandler.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,14 @@
 +// Common/NewHandler.h
 +
@@ -32524,7 +32524,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/NewHan
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StdAfx.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -32537,7 +32537,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StdAfx
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.cpp	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,93 @@
 +// Common/StringConvert.cpp
 +
@@ -32634,7 +32634,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/StringConvert.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringConvert.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,71 @@
 +// Common/StringConvert.h
 +
@@ -32709,7 +32709,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/String.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.cpp	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,198 @@
 +// Common/String.cpp
 +
@@ -32911,7 +32911,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/String.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/String.h	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,631 @@
 +// Common/String.h
 +
@@ -33546,7 +33546,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.cpp	2024-12-27 00:07:21.402156980 +0100
 @@ -0,0 +1,68 @@
 +// Common/StringToInt.cpp
 +
@@ -33618,7 +33618,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/StringToInt.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/StringToInt.h	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,17 @@
 +// Common/StringToInt.h
 +
@@ -33639,7 +33639,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/String
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/Types.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Types.h	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,19 @@
 +// Common/Types.h
 +
@@ -33662,7 +33662,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Types.
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.cpp	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,74 @@
 +// Common/Vector.cpp
 +
@@ -33740,7 +33740,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Common/Vector.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Common/Vector.h	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,211 @@
 +// Common/Vector.h
 +
@@ -33955,7 +33955,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Common/Vector
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/Defs.h	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,18 @@
 +// Windows/Defs.h
 +
@@ -33977,7 +33977,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/Defs.
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp
 --- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.cpp	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.cpp	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,245 @@
 +// Windows/FileIO.cpp
 +
@@ -34226,7 +34226,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +}}}
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Windows/FileIO.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/FileIO.h	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,98 @@
 +// Windows/FileIO.h
 +
@@ -34328,7 +34328,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/FileI
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h
 --- squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAfx.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/C/Windows/StdAfx.h	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,9 @@
 +// StdAfx.h
 +
@@ -34341,7 +34341,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/C/Windows/StdAf
 +#endif 
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squashfs-tools-patched/LZMA/lzmadaptive/CPL.html
 --- squashfs-tools/LZMA/lzmadaptive/CPL.html	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/CPL.html	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,224 @@
 +<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 +<HTML><HEAD><TITLE>Common Public License - v 1.0</TITLE>
@@ -34569,7 +34569,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/CPL.html squash
 +<P><FONT size=2></FONT></P></BODY></HTML>
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squashfs-tools-patched/LZMA/lzmadaptive/history.txt
 --- squashfs-tools/LZMA/lzmadaptive/history.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/history.txt	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,147 @@
 +HISTORY of the LZMA SDK
 +-----------------------
@@ -34720,7 +34720,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/history.txt squ
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt
 --- squashfs-tools/LZMA/lzmadaptive/LGPL.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/LGPL.txt	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,504 @@
 +      GNU LESSER GENERAL PUBLIC LICENSE
 +           Version 2.1, February 1999
@@ -35228,7 +35228,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/LGPL.txt squash
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt
 --- squashfs-tools/LZMA/lzmadaptive/lzma.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/lzma.txt	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,637 @@
 +LZMA SDK 4.32
 +-------------
@@ -35869,7 +35869,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/lzma.txt squash
 +http://www.7-zip.org/support.html
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt
 --- squashfs-tools/LZMA/lzmadaptive/Methods.txt	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmadaptive/Methods.txt	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,114 @@
 +Compression method IDs (4.27)
 +-----------------------------
@@ -35987,7 +35987,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmadaptive/Methods.txt squ
 +End of document
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-tools-patched/LZMA/lzmalt/7zlzma.c
 --- squashfs-tools/LZMA/lzmalt/7zlzma.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/7zlzma.c	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,58 @@
 +#include "lzmalt.h"
 +
@@ -36049,7 +36049,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/7zlzma.c squashfs-to
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h
 --- squashfs-tools/LZMA/lzmalt/AriBitCoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/AriBitCoder.h	2024-12-27 00:07:21.403156993 +0100
 @@ -0,0 +1,51 @@
 +#ifndef __COMPRESSION_BITCODER_H
 +#define __COMPRESSION_BITCODER_H
@@ -36104,7 +36104,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/AriBitCoder.h squash
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h
 --- squashfs-tools/LZMA/lzmalt/BitTreeCoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/BitTreeCoder.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,160 @@
 +#ifndef __BITTREECODER_H
 +#define __BITTREECODER_H
@@ -36268,7 +36268,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/BitTreeCoder.h squas
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c
 --- squashfs-tools/LZMA/lzmalt/IInOutStreams.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.c	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,39 @@
 +#include "stdlib.h"
 +#include "IInOutStreams.h"
@@ -36311,7 +36311,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.c squa
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h
 --- squashfs-tools/LZMA/lzmalt/IInOutStreams.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/IInOutStreams.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,62 @@
 +#ifndef __IINOUTSTREAMS_H
 +#define __IINOUTSTREAMS_H
@@ -36377,7 +36377,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/IInOutStreams.h squa
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-tools-patched/LZMA/lzmalt/LenCoder.h
 --- squashfs-tools/LZMA/lzmalt/LenCoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LenCoder.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,75 @@
 +#ifndef __LENCODER_H
 +#define __LENCODER_H
@@ -36456,7 +36456,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LenCoder.h squashfs-
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h
 --- squashfs-tools/LZMA/lzmalt/LiteralCoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LiteralCoder.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,146 @@
 +#ifndef __LITERALCODER_H
 +#define __LITERALCODER_H
@@ -36606,7 +36606,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LiteralCoder.h squas
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c
 --- squashfs-tools/LZMA/lzmalt/LZMADecoder.c	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.c	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,417 @@
 +#include "Portable.h"
 +#include "stdio.h"
@@ -37027,7 +37027,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.c squash
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h
 --- squashfs-tools/LZMA/lzmalt/LZMADecoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LZMADecoder.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,60 @@
 +#ifndef __LZARITHMETIC_DECODER_H
 +#define __LZARITHMETIC_DECODER_H
@@ -37091,7 +37091,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMADecoder.h squash
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tools-patched/LZMA/lzmalt/LZMA.h
 --- squashfs-tools/LZMA/lzmalt/LZMA.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/LZMA.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,83 @@
 +#include "LenCoder.h"
 +
@@ -37178,7 +37178,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/LZMA.h squashfs-tool
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-tools-patched/LZMA/lzmalt/lzmalt.h
 --- squashfs-tools/LZMA/lzmalt/lzmalt.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/lzmalt.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,16 @@
 +#ifndef __7Z_H
 +#define __7Z_H
@@ -37198,7 +37198,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/lzmalt.h squashfs-to
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-tools-patched/LZMA/lzmalt/Makefile
 --- squashfs-tools/LZMA/lzmalt/Makefile	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/Makefile	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,10 @@
 +INCLUDEDIR = .
 +
@@ -37212,7 +37212,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Makefile squashfs-to
 +	rm -f *.o
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-tools-patched/LZMA/lzmalt/Portable.h
 --- squashfs-tools/LZMA/lzmalt/Portable.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/Portable.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,59 @@
 +#ifndef __PORTABLE_H
 +#define __PORTABLE_H
@@ -37275,7 +37275,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/Portable.h squashfs-
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h
 --- squashfs-tools/LZMA/lzmalt/RangeCoder.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/RangeCoder.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,56 @@
 +#ifndef __COMPRESSION_RANGECODER_H
 +#define __COMPRESSION_RANGECODER_H
@@ -37335,7 +37335,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RangeCoder.h squashf
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-tools-patched/LZMA/lzmalt/RCDefs.h
 --- squashfs-tools/LZMA/lzmalt/RCDefs.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/RCDefs.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,43 @@
 +#ifndef __RCDEFS_H
 +#define __RCDEFS_H
@@ -37382,7 +37382,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/RCDefs.h squashfs-to
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h
 --- squashfs-tools/LZMA/lzmalt/vxTypesOld.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/vxTypesOld.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,289 @@
 +/* vxTypesOld.h - old VxWorks type definition header */
 +
@@ -37675,7 +37675,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/vxTypesOld.h squashf
 +#endif /* __INCvxTypesOldh */
 diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs-tools-patched/LZMA/lzmalt/WindowOut.h
 --- squashfs-tools/LZMA/lzmalt/WindowOut.h	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/LZMA/lzmalt/WindowOut.h	2024-12-27 00:07:21.404157006 +0100
 @@ -0,0 +1,52 @@
 +#ifndef __STREAM_WINDOWOUT_H
 +#define __STREAM_WINDOWOUT_H
@@ -37731,7 +37731,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/LZMA/lzmalt/WindowOut.h squashfs
 +#endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-patched/lzma_wrapper.c
 --- squashfs-tools/lzma_wrapper.c	2014-03-09 06:31:58.000000000 +0100
-+++ squashfs-tools-patched/lzma_wrapper.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/lzma_wrapper.c	2024-12-27 00:07:21.404157006 +0100
 @@ -27,14 +27,21 @@
  #include "squashfs_fs.h"
  #include "compressor.h"
@@ -38078,7 +38078,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/lzma_wrapper.c squashfs-tools-pa
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/Makefile
 --- squashfs-tools/Makefile	2014-05-11 20:56:00.000000000 +0200
-+++ squashfs-tools-patched/Makefile	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/Makefile	2024-12-27 00:08:19.239940915 +0100
 @@ -26,7 +26,7 @@
  # To build using XZ Utils liblzma - install the library and uncomment
  # the XZ_SUPPORT line below.
@@ -38123,7 +38123,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  CFLAGS += $(EXTRA_CFLAGS) $(INCLUDEDIR) -D_FILE_OFFSET_BITS=64 \
  	-D_LARGEFILE_SOURCE -D_GNU_SOURCE -DCOMP_DEFAULT=\"$(COMP_DEFAULT)\" \
 -	-Wall
-+	-Wall -Werror #-DSQUASHFS_TRACE
++	-Wall -Wno-error #-DSQUASHFS_TRACE
  
  LIBS = -lpthread -lm
  ifeq ($(GZIP_SUPPORT),1)
@@ -38132,7 +38132,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  
  ifeq ($(LZMA_SUPPORT),1)
 +# CJH: Added -llzmalib
-+LIBS += -L$(LZMA_ADAPT_DIR) -llzmalib 
++LIBS += -L$(LZMA_ADAPT_DIR) -llzmalib
  LZMA_OBJS = $(LZMA_DIR)/C/Alloc.o $(LZMA_DIR)/C/LzFind.o \
  	$(LZMA_DIR)/C/LzmaDec.o $(LZMA_DIR)/C/LzmaEnc.o $(LZMA_DIR)/C/LzmaLib.o
 -INCLUDEDIR += -I$(LZMA_DIR)/C
@@ -38153,7 +38153,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
  .PHONY: all
 -all: mksquashfs unsquashfs
 +# CJH: Made sasquatch the default target
-+all: sasquatch 
++all: sasquatch
  
 +# CJH: Added LZMA_EXTRA_OBJS
  mksquashfs: $(MKSQUASHFS_OBJS)
@@ -38216,7 +38216,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/Makefile squashfs-tools-patched/
 +	cp sasquatch $(INSTALL_DIR)
 diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-tools-patched/process_fragments.c
 --- squashfs-tools/process_fragments.c	2014-05-10 06:54:13.000000000 +0200
-+++ squashfs-tools-patched/process_fragments.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/process_fragments.c	2024-12-27 00:07:21.405157020 +0100
 @@ -192,9 +192,10 @@
  
  		res = compressor_uncompress(comp, buffer->data, data, size,
@@ -38233,7 +38233,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/process_fragments.c squashfs-too
  	else {
 diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched/read_fs.c
 --- squashfs-tools/read_fs.c	2014-05-10 06:54:13.000000000 +0200
-+++ squashfs-tools-patched/read_fs.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/read_fs.c	2024-12-27 00:07:21.405157020 +0100
 @@ -87,8 +87,9 @@
  		res = compressor_uncompress(comp, block, buffer, c_byte,
  			outlen, &error);
@@ -38248,13 +38248,13 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/read_fs.c squashfs-tools-patched
  	} else {
 diff --strip-trailing-cr -NBbaur squashfs-tools/README.md squashfs-tools-patched/README.md
 --- squashfs-tools/README.md	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/README.md	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/README.md	2024-12-27 00:07:21.405157020 +0100
 @@ -0,0 +1,2 @@
 +This is the raw, patched source code for squashfs-tools. It is included in this repository for documentation and administrative purposes only. Any bugs or patches not directly related to the modifications made by the sasquatch patches should be reported to the squashfs-tools project.
 +
 diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-patched/squashfs_fs.h
 --- squashfs-tools/squashfs_fs.h	2014-05-10 06:54:13.000000000 +0200
-+++ squashfs-tools-patched/squashfs_fs.h	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/squashfs_fs.h	2024-12-27 00:07:21.405157020 +0100
 @@ -277,6 +277,22 @@
  #define LZO_COMPRESSION		3
  #define XZ_COMPRESSION		4
@@ -38302,7 +38302,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/squashfs_fs.h squashfs-tools-pat
  #endif
 diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patched/unsquashfs.c
 --- squashfs-tools/unsquashfs.c	2014-05-13 00:18:35.000000000 +0200
-+++ squashfs-tools-patched/unsquashfs.c	2023-05-23 16:19:06.325285093 +0200
++++ squashfs-tools-patched/unsquashfs.c	2024-12-27 00:07:21.406157033 +0100
 @@ -33,24 +33,32 @@
  
  #include <sys/sysinfo.h>
@@ -38731,7 +38731,7 @@ diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c squashfs-tools-patc
  		}
 diff --strip-trailing-cr -NBbaur squashfs-tools/unsquashfs.c.orig squashfs-tools-patched/unsquashfs.c.orig
 --- squashfs-tools/unsquashfs.c.orig	1970-01-01 01:00:00.000000000 +0100
-+++ squashfs-tools-patched/unsquashfs.c.orig	2023-05-23 16:19:06.321285058 +0200
++++ squashfs-tools-patched/unsquashfs.c.orig	2024-12-27 00:07:21.407157046 +0100
 @@ -0,0 +1,2814 @@
 +/*
 + * Unsquash a squashfs filesystem.  This is a highly compressed read only

--- a/patches/patch1.txt
+++ b/patches/patch1.txt
@@ -1,0 +1,22 @@
+--- squashfs-tools/Makefile
++++ squashfs-tools/Makefile
+@@ -143,7 +143,8 @@
+ LZMA_OBJS = $(LZMA_DIR)/C/Alloc.o $(LZMA_DIR)/C/LzFind.o \
+ 	$(LZMA_DIR)/C/LzmaDec.o $(LZMA_DIR)/C/LzmaEnc.o $(LZMA_DIR)/C/LzmaLib.o
+ # CJH: Added LZMA variant directories
+-INCLUDEDIR += -I$(LZMA_DIR)/C -I$(LZMA_ALT_DIR) -I$(LZMA_ADAPT_DIR)
++LEGACY_LZMA_INCLUDES = -I$(LZMA_DIR)/C -I$(LZMA_ALT_DIR) -I$(LZMA_ADAPT_DIR)
++INCLUDEDIR += $(LEGACY_LZMA_INCLUDES)
+ CFLAGS += -DLZMA_SUPPORT
+ MKSQUASHFS_OBJS += lzma_wrapper.o $(LZMA_OBJS)
+ UNSQUASHFS_OBJS += lzma_wrapper.o $(LZMA_OBJS)
+@@ -287,6 +288,9 @@
+ 
+ lz4_wrapper.o: lz4_wrapper.c squashfs_fs.h lz4_wrapper.h compressor.h
+ 
++# xz_wrapper.c uses XZ Utils liblzma via <lzma.h>.
++# Do not let bundled legacy LZMA SDK headers shadow the system liblzma header.
++xz_wrapper.o: CFLAGS := $(filter-out $(LEGACY_LZMA_INCLUDES),$(CFLAGS))
+ xz_wrapper.o: xz_wrapper.c squashfs_fs.h xz_wrapper.h compressor.h
+ 
+ # CJH: Added LZMA_EXTRA_OBJS


### PR DESCRIPTION
## Summary

This PR builds on #56 and fixes a long-standing XZ build failure where the bundled legacy LZMA SDK header shadows the system XZ Utils/liblzma header.

When both `XZ_SUPPORT` and legacy `LZMA_SUPPORT` are enabled, `xz_wrapper.c` includes `<lzma.h>` and expects the system liblzma header from `liblzma-dev`.

However, the Makefile adds bundled legacy LZMA include paths globally, including:

```make
-I$(LZMA_ALT_DIR)
````

That can cause GCC to include:

```text
./LZMA/lzmalt/lzma.h
```

instead of the system liblzma header:

```text
/usr/include/lzma.h
```

The bundled legacy header does not define XZ/liblzma types such as `lzma_vli`, `lzma_filter`, and `lzma_options_lzma`, so the build fails.

## Fix

This PR adds a small follow-up patch, `patches/patch1.txt`, and updates `build.sh` to apply all `patch*.txt` files in order.

The patch keeps legacy LZMA include paths for the legacy LZMA code, but removes them when compiling `xz_wrapper.o`, allowing `<lzma.h>` to resolve to the system liblzma header without hardcoding `/usr/include/lzma.h`.

## Why not hardcode `/usr/include/lzma.h`?

Hardcoding this:

```c
#include "/usr/include/lzma.h"
```

works on Ubuntu, but it is not portable to other Linux distributions, sysroots, cross-compilers, or custom install prefixes. Fixing the Makefile include path is more maintainable.

## Tested

Tested with:

```bash
rm -rf squashfs4.3
./build.sh

cd squashfs4.3/squashfs-tools
make clean
make CC="gcc -H" > /tmp/sasquatch-build.log 2>&1
grep -i 'lzma.h' /tmp/sasquatch-build.log
```

Before:

```text
./LZMA/lzmalt/lzma.h
```

After:

```text
/usr/include/lzma.h
```

Also verified that the final binary links against liblzma:

```bash
ldd ./sasquatch | grep lzma
```

## Related

* Builds on modern Ubuntu: #56
* Original `lzma_vli` / `lzma_filter` failure: #6
